### PR TITLE
[Feat] #24 - OKR 생성, 삭제 API 구현

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
@@ -1,0 +1,35 @@
+package org.moonshot.server.domain.keyresult.controller;
+
+import static org.moonshot.server.global.common.response.SuccessType.*;
+
+import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultDeleteRequestDto;
+import org.moonshot.server.domain.keyresult.service.KeyResultService;
+import org.moonshot.server.global.common.response.ApiResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/key-result")
+public class KeyResultController {
+
+    private final KeyResultService keyResultService;
+
+    @PostMapping
+    public ApiResponse<?> create(@RequestBody KeyResultCreateRequestDto request) {
+        keyResultService.create(request);
+        return ApiResponse.success(POST_KEY_RESULT_SUCCESS);
+    }
+
+    @DeleteMapping
+    public ApiResponse<?> delete(@RequestBody KeyResultDeleteRequestDto request) {
+        keyResultService.delete(request.keyResultIds());
+        return ApiResponse.success(DELETE_KEY_RESULT_SUCCESS);
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
@@ -21,14 +21,14 @@ public class KeyResultController {
     private final KeyResultService keyResultService;
 
     @PostMapping
-    public ApiResponse<?> create(@RequestBody KeyResultCreateRequestDto request) {
-        keyResultService.create(request);
+    public ApiResponse<?> createKeyResult(@RequestBody KeyResultCreateRequestDto request) {
+        keyResultService.createKeyResult(request);
         return ApiResponse.success(POST_KEY_RESULT_SUCCESS);
     }
 
     @DeleteMapping
-    public ApiResponse<?> delete(@RequestBody KeyResultDeleteRequestDto request) {
-        keyResultService.delete(request.keyResultIds());
+    public ApiResponse<?> deleteKeyResult(@RequestBody KeyResultDeleteRequestDto request) {
+        keyResultService.deleteKeyResult(request.keyResultIds());
         return ApiResponse.success(DELETE_KEY_RESULT_SUCCESS);
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -3,12 +3,30 @@ package org.moonshot.server.domain.keyresult.dto.request;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
 
 public record KeyResultCreateRequestDto(
         @NotNull(message = "KR이 생성될 ObjectiveId를 입력해주세요.")
         Long objectiveId,
-        @NotNull @Valid @Size(max = 3)
-        List<KeyResultCreateRequestInfoDto> krList
+        @Size(min = 1, max = 30, message = "KR은 30자 이하여야 합니다.")
+        String title,
+        @NotNull(message = "KR 시작 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime startAt,
+        @NotNull(message = "KR 종료 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime expireAt,
+        @NotNull(message = "KR의 순서를 입력해주세요.")
+        short order,
+        @NotNull(message = "KR 목표 수치를 입력해주세요.")
+        int target,
+        @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
+        String metric,
+        @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")
+        String descriptionBefore,
+        @NotNull(message = "KR 목표의 이후 수식을 입력해주세요.")
+        String descriptionAfter
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -1,0 +1,14 @@
+package org.moonshot.server.domain.keyresult.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record KeyResultCreateRequestDto(
+        @NotNull(message = "KR이 생성될 ObjectiveId를 입력해주세요.")
+        Long objectiveId,
+        @NotNull @Valid @Size(max = 3)
+        List<KeyResultCreateRequestInfoDto> krList
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -19,7 +19,7 @@ public record KeyResultCreateRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
-        short order,
+        short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
         int target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -18,7 +18,7 @@ public record KeyResultCreateRequestInfoDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
-        short order,
+        short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
         int target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -1,0 +1,33 @@
+package org.moonshot.server.domain.keyresult.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.moonshot.server.domain.objective.dto.request.TaskCreateRequestDto;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record KeyResultCreateRequestInfoDto(
+        @Size(min = 1, max = 30, message = "KR은 30자 이하여야 합니다.")
+        String title,
+        @NotNull(message = "KR 시작 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime startAt,
+        @NotNull(message = "KR 종료 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime expireAt,
+        @NotNull(message = "KR의 순서를 입력해주세요.")
+        short order,
+        @NotNull(message = "KR 목표 수치를 입력해주세요.")
+        int target,
+        @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
+        String metric,
+        @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")
+        String descriptionBefore,
+        @NotNull(message = "KR 목표의 이후 수식을 입력해주세요.")
+        String descriptionAfter,
+        @Valid @Size(max = 3, message = "Task 개수는 최대 3개로 제한되어 있습니다.")
+        List<TaskCreateRequestDto> taskList
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultDeleteRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultDeleteRequestDto.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.keyresult.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record KeyResultDeleteRequestDto(
+        @NotNull
+        List<Long> keyResultIds
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultInvalidPositionException.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultInvalidPositionException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.keyresult.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class KeyResultInvalidPositionException extends MoonshotException {
+    public KeyResultInvalidPositionException() {
+        super(ErrorType.INVALID_KEY_RESULT_ORDER);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNumberExceededException.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNumberExceededException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.keyresult.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class KeyResultNumberExceededException extends MoonshotException {
+    public KeyResultNumberExceededException() {
+        super(ErrorType.KEY_RESULT_NUMBER_EXCEEDED);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KRState.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KRState.java
@@ -1,4 +1,4 @@
-package org.moonshot.server.domain.keyResult.model;
+package org.moonshot.server.domain.keyresult.model;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -35,7 +35,7 @@ public class KeyResult {
     private int target;
 
     @Column(nullable = false)
-    private short order;
+    private short idx;
 
     @Column(nullable = false)
     private String metric;
@@ -54,7 +54,7 @@ public class KeyResult {
     @JoinColumn(name = "objective_id")
     private Objective objective;
 
-    public void incrementOrder() {
-        ++this.order;
+    public void incrementIdx() {
+        ++this.idx;
     }
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -2,6 +2,7 @@ package org.moonshot.server.domain.keyresult.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
 import org.moonshot.server.domain.log.model.Log;
 import org.moonshot.server.domain.task.model.Task;
 import org.moonshot.server.domain.objective.model.Objective;
@@ -13,6 +14,7 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class KeyResult {
@@ -41,7 +43,7 @@ public class KeyResult {
     private String descriptionAfter;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "enum('DONE','HOLD','PROGRESS','WAITING') default 'PROGRESS'")
     private KRState state;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -1,4 +1,4 @@
-package org.moonshot.server.domain.keyResult.model;
+package org.moonshot.server.domain.keyresult.model;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,10 +29,16 @@ public class KeyResult {
     private Period period;
 
     @Column(nullable = false)
-    private int count;
+    private int target;
 
     @Column(nullable = false)
     private String metric;
+
+    @Column(nullable = false)
+    private String descriptionBefore;
+
+    @Column(nullable = false)
+    private String descriptionAfter;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -41,11 +47,5 @@ public class KeyResult {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "objective_id")
     private Objective objective;
-
-    @OneToMany(mappedBy = "keyResult", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Task> taskList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "keyResult", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Log> logList = new ArrayList<>();
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -1,5 +1,6 @@
 package org.moonshot.server.domain.keyresult.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -34,6 +35,9 @@ public class KeyResult {
     private int target;
 
     @Column(nullable = false)
+    private short order;
+
+    @Column(nullable = false)
     private String metric;
 
     @Column(nullable = false)
@@ -50,4 +54,7 @@ public class KeyResult {
     @JoinColumn(name = "objective_id")
     private Objective objective;
 
+    public void incrementOrder() {
+        ++this.order;
+    }
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
 
+    Long countAllByObjective(Objective objective);
+    List<KeyResult> findByIdIn(List<Long> ids);
     List<KeyResult> findAllByObjective(Objective objective);
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
@@ -1,0 +1,12 @@
+package org.moonshot.server.domain.keyresult.repository;
+
+import java.util.List;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
+import org.moonshot.server.domain.objective.model.Objective;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
+
+    List<KeyResult> findAllByObjective(Objective objective);
+
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -1,0 +1,44 @@
+package org.moonshot.server.domain.keyresult.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.keyresult.model.KRState;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
+import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
+import org.moonshot.server.domain.objective.dto.request.KRCreateRequestDto;
+import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.task.model.Task;
+import org.moonshot.server.domain.task.repository.TaskRepository;
+import org.moonshot.server.global.common.model.Period;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class KeyResultService {
+
+    private final KeyResultRepository keyResultRepository;
+    private final TaskRepository taskRepository;
+
+    @Transactional
+    public void createInitWithObjective(Objective objective, List<KRCreateRequestDto> requests) {
+        for (KRCreateRequestDto it : requests) {
+            KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
+                    .title(it.title())
+                    .period(Period.of(it.startAt(), it.expireAt()))
+                    .target(it.target())
+                    .metric(it.metric())
+                    .descriptionBefore(it.descriptionBefore())
+                    .descriptionAfter(it.descriptionAfter())
+                    .objective(objective)
+                    .build());
+            taskRepository.saveAll(it.taskList().stream().map((task) -> Task.builder()
+                    .title(task.title())
+                    .keyResult(keyResult)
+                    .build()).toList());
+        }
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -34,7 +34,7 @@ public class KeyResultService {
             KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
                     .title(dto.title())
                     .period(Period.of(dto.startAt(), dto.expireAt()))
-                    .order(dto.order())
+                    .idx(dto.idx())
                     .target(dto.target())
                     .metric(dto.metric())
                     .descriptionBefore(dto.descriptionBefore())
@@ -44,7 +44,7 @@ public class KeyResultService {
             if (dto.taskList() != null) {
                 taskRepository.saveAll(dto.taskList().stream().map((task) -> Task.builder()
                         .title(task.title())
-                        .order(task.order())
+                        .idx(task.idx())
                         .keyResult(keyResult)
                         .build()).toList());
             }
@@ -60,18 +60,18 @@ public class KeyResultService {
         if (krList.size() >= ACTIVE_KEY_RESULT_NUMBER) {
             throw new KeyResultNumberExceededException();
         }
-        if (request.order() > krList.size()) {
+        if (request.idx() > krList.size()) {
             throw new KeyResultInvalidPositionException();
         }
 
-        for (short i = request.order(); i < krList.size(); i++) {
-            krList.get(i).incrementOrder();
+        for (short i = request.idx(); i < krList.size(); i++) {
+            krList.get(i).incrementIdx();
         }
         keyResultRepository.save(KeyResult.builder()
                 .objective(objective)
                 .title(request.title())
                 .period(Period.of(request.startAt(), request.expireAt()))
-                .order(request.order())
+                .idx(request.idx())
                 .target(request.target())
                 .metric(request.metric())
                 .descriptionBefore(request.descriptionBefore())

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -1,13 +1,15 @@
 package org.moonshot.server.domain.keyresult.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.moonshot.server.domain.keyresult.model.KRState;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestInfoDto;
+import org.moonshot.server.domain.keyresult.exception.KeyResultNumberExceededException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
-import org.moonshot.server.domain.objective.dto.request.KRCreateRequestDto;
+import org.moonshot.server.domain.objective.exception.ObjectiveNotFoundException;
 import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.objective.repository.ObjectiveRepository;
 import org.moonshot.server.domain.task.model.Task;
 import org.moonshot.server.domain.task.repository.TaskRepository;
 import org.moonshot.server.global.common.model.Period;
@@ -19,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class KeyResultService {
 
+    private static final int ACTIVE_KEY_RESULT_NUMBER = 3;
+
+    private final ObjectiveRepository objectiveRepository;
     private final KeyResultRepository keyResultRepository;
     private final TaskRepository taskRepository;
 

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -23,20 +23,22 @@ public class KeyResultService {
     private final TaskRepository taskRepository;
 
     @Transactional
-    public void createInitWithObjective(Objective objective, List<KRCreateRequestDto> requests) {
-        for (KRCreateRequestDto it : requests) {
+    public void createInitWithObjective(Objective objective, List<KeyResultCreateRequestInfoDto> requests) {
+        for (KeyResultCreateRequestInfoDto dto : requests) {
             KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
-                    .title(it.title())
-                    .period(Period.of(it.startAt(), it.expireAt()))
-                    .target(it.target())
-                    .metric(it.metric())
-                    .descriptionBefore(it.descriptionBefore())
-                    .descriptionAfter(it.descriptionAfter())
+                    .title(dto.title())
+                    .period(Period.of(dto.startAt(), dto.expireAt()))
+                    .order(dto.order())
+                    .target(dto.target())
+                    .metric(dto.metric())
+                    .descriptionBefore(dto.descriptionBefore())
+                    .descriptionAfter(dto.descriptionAfter())
                     .objective(objective)
                     .build());
-            if (it.taskList() != null) {
-                taskRepository.saveAll(it.taskList().stream().map((task) -> Task.builder()
+            if (dto.taskList() != null) {
+                taskRepository.saveAll(dto.taskList().stream().map((task) -> Task.builder()
                         .title(task.title())
+                        .order(task.order())
                         .keyResult(keyResult)
                         .build()).toList());
             }

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -28,7 +28,7 @@ public class KeyResultService {
     private final TaskRepository taskRepository;
 
     @Transactional
-    public void createInitWithObjective(Objective objective, List<KeyResultCreateRequestInfoDto> requests) {
+    public void createInitKRWithObjective(Objective objective, List<KeyResultCreateRequestInfoDto> requests) {
         for (KeyResultCreateRequestInfoDto dto : requests) {
             KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
                     .title(dto.title())
@@ -51,7 +51,7 @@ public class KeyResultService {
     }
 
     @Transactional
-    public void create(KeyResultCreateRequestDto request) {
+    public void createKeyResult(KeyResultCreateRequestDto request) {
         Objective objective = objectiveRepository.findById(request.objectiveId())
                 .orElseThrow(ObjectiveNotFoundException::new);
         List<KeyResult> krList = keyResultRepository.findAllByObjective(objective);
@@ -84,12 +84,12 @@ public class KeyResultService {
     }
 
     @Transactional
-    public void delete(List<Long> keyResultIds) {
+    public void deleteKeyResult(List<Long> keyResultIds) {
         cascadeDelete(keyResultRepository.findByIdIn(keyResultIds));
     }
 
     @Transactional
-    public void delete(Objective objective) {
+    public void deleteKeyResult(Objective objective) {
         cascadeDelete(keyResultRepository.findAllByObjective(objective));
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -34,10 +34,12 @@ public class KeyResultService {
                     .descriptionAfter(it.descriptionAfter())
                     .objective(objective)
                     .build());
-            taskRepository.saveAll(it.taskList().stream().map((task) -> Task.builder()
-                    .title(task.title())
-                    .keyResult(keyResult)
-                    .build()).toList());
+            if (it.taskList() != null) {
+                taskRepository.saveAll(it.taskList().stream().map((task) -> Task.builder()
+                        .title(task.title())
+                        .keyResult(keyResult)
+                        .build()).toList());
+            }
         }
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -45,4 +45,54 @@ public class KeyResultService {
         }
     }
 
+    @Transactional
+    public void create(KeyResultCreateRequestDto request) {
+        Objective objective = objectiveRepository.findById(request.objectiveId())
+                .orElseThrow(ObjectiveNotFoundException::new);
+        List<KeyResult> krList = keyResultRepository.findAllByObjective(objective);
+
+        if (krList.size() + request.krList().size() > ACTIVE_KEY_RESULT_NUMBER) {
+            throw new KeyResultNumberExceededException();
+        }
+
+        for (KeyResultCreateRequestInfoDto dto : request.krList()) {
+            for (short i = dto.order(); i < krList.size(); i++) {
+                krList.get(i).incrementOrder();
+            }
+            KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
+                    .title(dto.title())
+                    .period(Period.of(dto.startAt(), dto.expireAt()))
+                    .order(dto.order())
+                    .target(dto.target())
+                    .metric(dto.metric())
+                    .descriptionBefore(dto.descriptionBefore())
+                    .descriptionAfter(dto.descriptionAfter()).build());
+            if (dto.taskList() != null) {
+                taskRepository.saveAll(
+                        dto.taskList().stream().map((task) -> Task.builder()
+                        .title(task.title())
+                        .order(task.order())
+                        .keyResult(keyResult)
+                        .build()).toList());
+            }
+        }
+    }
+
+    @Transactional
+    public void delete(List<Long> keyResultIds) {
+        cascadeDelete(keyResultRepository.findByIdIn(keyResultIds));
+    }
+
+    @Transactional
+    public void delete(Objective objective) {
+        cascadeDelete(keyResultRepository.findAllByObjective(objective));
+    }
+
+    private void cascadeDelete(List<KeyResult> krList) {
+        krList.forEach((kr) -> {
+            taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResult(kr));
+        });
+        keyResultRepository.deleteAllInBatch(krList);
+    }
+
 }

--- a/src/main/java/org/moonshot/server/domain/log/model/Log.java
+++ b/src/main/java/org/moonshot/server/domain/log/model/Log.java
@@ -3,7 +3,7 @@ package org.moonshot.server.domain.log.model;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-import org.moonshot.server.domain.keyResult.model.KeyResult;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -1,0 +1,31 @@
+package org.moonshot.server.domain.objective.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
+import org.moonshot.server.domain.objective.service.ObjectiveService;
+import org.moonshot.server.global.common.response.ApiResponse;
+import org.moonshot.server.global.common.response.SuccessType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/okr")
+public class ObjectiveController {
+
+    private final ObjectiveService objectiveService;
+
+    @PostMapping
+    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request,
+                                 String nickname) {
+        final String TEST_USER_NICKNAME = "tester";
+        objectiveService.create(request, TEST_USER_NICKNAME);
+        return ApiResponse.success(SuccessType.POST_OKR_SUCCESS);
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -7,9 +7,11 @@ import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
 import org.moonshot.server.domain.objective.service.ObjectiveService;
 import org.moonshot.server.global.common.response.ApiResponse;
 import org.moonshot.server.global.common.response.SuccessType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -19,12 +21,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class ObjectiveController {
 
     private final ObjectiveService objectiveService;
+    private final String TEST_USER_NICKNAME = "tester";
 
     @PostMapping
-    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request, String nickname) {
-        final String TEST_USER_NICKNAME = "tester";
+    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request) {
         objectiveService.create(request, TEST_USER_NICKNAME);
         return ApiResponse.success(SuccessType.POST_OKR_SUCCESS);
     }
+
+    //TODO
+    // PATCH API (목표 히스토리로 넘기기 - 상태수정)
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -7,11 +7,9 @@ import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
 import org.moonshot.server.domain.objective.service.ObjectiveService;
 import org.moonshot.server.global.common.response.ApiResponse;
 import org.moonshot.server.global.common.response.SuccessType;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -24,8 +22,8 @@ public class ObjectiveController {
     private final String TEST_USER_NICKNAME = "tester";
 
     @PostMapping
-    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request) {
-        objectiveService.create(request, TEST_USER_NICKNAME);
+    public ApiResponse<?> createObjective(@RequestBody @Valid OKRCreateRequestDto request) {
+        objectiveService.createObjective(request, TEST_USER_NICKNAME);
         return ApiResponse.success(SuccessType.POST_OKR_SUCCESS);
     }
 

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -15,14 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/okr")
+@RequestMapping("/v1/objective")
 public class ObjectiveController {
 
     private final ObjectiveService objectiveService;
 
     @PostMapping
-    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request,
-                                 String nickname) {
+    public ApiResponse<?> create(@RequestBody @Valid OKRCreateRequestDto request, String nickname) {
         final String TEST_USER_NICKNAME = "tester";
         objectiveService.create(request, TEST_USER_NICKNAME);
         return ApiResponse.success(SuccessType.POST_OKR_SUCCESS);

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
@@ -1,0 +1,30 @@
+package org.moonshot.server.domain.objective.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record KRCreateRequestDto(
+        @Size(min = 1, max = 30, message = "KR은 30자 이하여야 합니다.")
+        String title,
+        @NotNull(message = "KR 시작 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime startAt,
+        @NotNull(message = "KR 종료 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime expireAt,
+        @NotNull(message = "KR 목표 수치를 입력해주세요.")
+        int target,
+        @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
+        String metric,
+        @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")
+        String descriptionBefore,
+        @NotNull(message = "KR 목표의 이후 수식을 입력해주세요.")
+        String descriptionAfter,
+        @NotNull @Valid @Size(max = 3, message = "Task 개수는 최대 3개로 제한되어 있습니다.")
+        List<TaskCreateRequestDto> taskList
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
@@ -24,7 +24,7 @@ public record KRCreateRequestDto(
         String descriptionBefore,
         @NotNull(message = "KR 목표의 이후 수식을 입력해주세요.")
         String descriptionAfter,
-        @NotNull @Valid @Size(max = 3, message = "Task 개수는 최대 3개로 제한되어 있습니다.")
+        @Valid @Size(max = 3, message = "Task 개수는 최대 3개로 제한되어 있습니다.")
         List<TaskCreateRequestDto> taskList
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/OKRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/OKRCreateRequestDto.java
@@ -1,0 +1,27 @@
+package org.moonshot.server.domain.objective.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.moonshot.server.domain.objective.model.Category;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record OKRCreateRequestDto(
+        @Size(min = 1, max = 30, message = "제목은 30자 이하여야 합니다.")
+        String objTitle,
+        @NotNull(message = "카테고리를 선택해야 합니다.")
+        Category objCategory,
+        @Size(min = 1, max = 100, message = "본문은 100자 이하여야 합니다.")
+        String objContent,
+        @NotNull(message = "목표 시작 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime objStartAt,
+        @NotNull(message = "목표 종료 날짜를 선택해주세요.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime objExpireAt,
+        @NotNull @Valid @Size(min = 1, max = 3, message = "KR 개수는 1~3개로 제한되어 있습니다.")
+        List<KRCreateRequestDto> krList
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/OKRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/OKRCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestInfoDto;
 import org.moonshot.server.domain.objective.model.Category;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -22,6 +23,6 @@ public record OKRCreateRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime objExpireAt,
         @NotNull @Valid @Size(min = 1, max = 3, message = "KR 개수는 1~3개로 제한되어 있습니다.")
-        List<KRCreateRequestDto> krList
+        List<KeyResultCreateRequestInfoDto> krList
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
@@ -1,0 +1,9 @@
+package org.moonshot.server.domain.objective.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record TaskCreateRequestDto(
+        @Size(min = 1, max = 30, message = "Task는 30자 이하여야 합니다.")
+        String title
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
@@ -7,6 +7,6 @@ public record TaskCreateRequestDto(
         @Size(min = 1, max = 30, message = "Task는 30자 이하여야 합니다.")
         String title,
         @NotNull(message = "KR 순서를 입력해주세요")
-        short order
+        short idx
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
@@ -1,9 +1,12 @@
 package org.moonshot.server.domain.objective.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record TaskCreateRequestDto(
         @Size(min = 1, max = 30, message = "Task는 30자 이하여야 합니다.")
-        String title
+        String title,
+        @NotNull(message = "KR 순서를 입력해주세요")
+        short order
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNotFoundException.java
@@ -4,7 +4,9 @@ import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
 
 public class ObjectiveNotFoundException extends MoonshotException {
+
     public ObjectiveNotFoundException() {
         super(ErrorType.NOT_FOUND_OBJECTIVE_ERROR);
     }
+
 }

--- a/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNotFoundException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.objective.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class ObjectiveNotFoundException extends MoonshotException {
+    public ObjectiveNotFoundException() {
+        super(ErrorType.NOT_FOUND_OBJECTIVE_ERROR);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNumberExceededException.java
+++ b/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveNumberExceededException.java
@@ -1,0 +1,12 @@
+package org.moonshot.server.domain.objective.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class ObjectiveNumberExceededException extends MoonshotException {
+
+    public ObjectiveNumberExceededException() {
+        super(ErrorType.ACTIVE_OBJECTIVE_NUMBER_EXCEEDED);
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
@@ -52,12 +52,9 @@ public class Objective {
     @ColumnDefault("-1")
     private short order;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
-
-    @OneToMany(mappedBy = "objective", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<KeyResult> keyResultList = new ArrayList<>();
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
@@ -1,11 +1,13 @@
 package org.moonshot.server.domain.objective.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.moonshot.server.domain.keyResult.model.KeyResult;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.user.model.User;
 import org.moonshot.server.global.common.model.Period;
 
@@ -15,6 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Objective {
@@ -34,22 +37,20 @@ public class Objective {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    @ColumnDefault("false")
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean isPublic;
 
-    @Column(nullable = false)
-    @ColumnDefault("false")
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean isClosed;
 
-    @Column(nullable = false)
-    @ColumnDefault("0")
+    @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long heartCount;
 
     @Embedded
     private Period period;
 
-    private int order;
+    @ColumnDefault("-1")
+    private short order;
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveRepository.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveRepository.java
@@ -1,0 +1,11 @@
+package org.moonshot.server.domain.objective.repository;
+
+import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
+
+    Long countAllByUserAndIsClosed(User user, boolean isClosed);
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ObjectiveService {
 
-    private static final int ACTIVE_OBJECTIVE_NUMBER = 2;
+    private static final int ACTIVE_OBJECTIVE_NUMBER = 10;
 
     private final KeyResultService keyResultService;
     private final UserRepository userRepository;
@@ -29,7 +29,7 @@ public class ObjectiveService {
         User findUser = userRepository.findUserByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
 
-        if (objectiveRepository.countAllByUserAndIsClosed(findUser, false) > ACTIVE_OBJECTIVE_NUMBER) {
+        if (objectiveRepository.countAllByUserAndIsClosed(findUser, false) >= ACTIVE_OBJECTIVE_NUMBER) {
             throw new ObjectiveNumberExceededException();
         }
 

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ObjectiveService {
 
+    private static final int ACTIVE_OBJECTIVE_NUMBER = 2;
+
     private final KeyResultService keyResultService;
     private final UserRepository userRepository;
     private final ObjectiveRepository objectiveRepository;
@@ -27,7 +29,7 @@ public class ObjectiveService {
         User findUser = userRepository.findUserByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
 
-        if (objectiveRepository.countAllByUserAndIsClosed(findUser, false) > 2) {
+        if (objectiveRepository.countAllByUserAndIsClosed(findUser, false) > ACTIVE_OBJECTIVE_NUMBER) {
             throw new ObjectiveNumberExceededException();
         }
 

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -25,7 +25,7 @@ public class ObjectiveService {
     private final ObjectiveRepository objectiveRepository;
 
     @Transactional
-    public void create(OKRCreateRequestDto request, String nickname) {
+    public void createObjective(OKRCreateRequestDto request, String nickname) {
         User findUser = userRepository.findUserByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
 
@@ -40,7 +40,7 @@ public class ObjectiveService {
                 .period(Period.of(request.objStartAt(), request.objExpireAt()))
                 .user(findUser).build());
 
-        keyResultService.createInitWithObjective(newObjective, request.krList());
+        keyResultService.createInitKRWithObjective(newObjective, request.krList());
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -1,0 +1,44 @@
+package org.moonshot.server.domain.objective.service;
+
+import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.keyresult.service.KeyResultService;
+import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
+import org.moonshot.server.domain.objective.exception.ObjectiveNumberExceededException;
+import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.objective.repository.ObjectiveRepository;
+import org.moonshot.server.domain.user.exception.UserNotFoundException;
+import org.moonshot.server.domain.user.model.User;
+import org.moonshot.server.domain.user.repository.UserRepository;
+import org.moonshot.server.global.common.model.Period;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ObjectiveService {
+
+    private final KeyResultService keyResultService;
+    private final UserRepository userRepository;
+    private final ObjectiveRepository objectiveRepository;
+
+    @Transactional
+    public void create(OKRCreateRequestDto request, String nickname) {
+        User findUser = userRepository.findUserByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (objectiveRepository.countAllByUserAndIsClosed(findUser, false) > 2) {
+            throw new ObjectiveNumberExceededException();
+        }
+
+        Objective newObjective = objectiveRepository.save(Objective.builder()
+                .title(request.objTitle())
+                .category(request.objCategory())
+                .content(request.objContent())
+                .period(Period.of(request.objStartAt(), request.objExpireAt()))
+                .user(findUser).build());
+
+        keyResultService.createInitWithObjective(newObjective, request.krList());
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/task/model/Task.java
+++ b/src/main/java/org/moonshot/server/domain/task/model/Task.java
@@ -2,7 +2,7 @@ package org.moonshot.server.domain.task.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.moonshot.server.domain.keyResult.model.KeyResult;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
 
 @Entity
 @Getter

--- a/src/main/java/org/moonshot/server/domain/task/model/Task.java
+++ b/src/main/java/org/moonshot/server/domain/task/model/Task.java
@@ -20,13 +20,13 @@ public class Task {
     private String title;
 
     @Column(nullable = false)
-    private short order;
+    private short idx;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "key_result_id")
     private KeyResult keyResult;
 
-    public void incrementOrder() {
-        ++this.order;
+    public void incrementIdx() {
+        ++this.idx;
     }
 }

--- a/src/main/java/org/moonshot/server/domain/task/model/Task.java
+++ b/src/main/java/org/moonshot/server/domain/task/model/Task.java
@@ -19,8 +19,14 @@ public class Task {
     @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
+    private short order;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "key_result_id")
     private KeyResult keyResult;
 
+    public void incrementOrder() {
+        ++this.order;
+    }
 }

--- a/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package org.moonshot.server.domain.task.repository;
+
+import org.moonshot.server.domain.task.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
@@ -1,7 +1,12 @@
 package org.moonshot.server.domain.task.repository;
 
+import java.util.List;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.task.model.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    List<Task> findAllByKeyResult(KeyResult keyResult);
+
 }

--- a/src/main/java/org/moonshot/server/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.user.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class UserNotFoundException extends MoonshotException {
+    public UserNotFoundException() {
+        super(ErrorType.NOT_FOUND_USER_ERROR);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/user/model/User.java
+++ b/src/main/java/org/moonshot/server/domain/user/model/User.java
@@ -31,9 +31,6 @@ public class User {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
-    private String accessToken;
-
     @Column(unique = true)
     private String nickname;
 

--- a/src/main/java/org/moonshot/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/moonshot/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package org.moonshot.server.domain.user.repository;
+
+import java.util.Optional;
+import org.moonshot.server.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findUserByNickname(String nickname);
+
+}

--- a/src/main/java/org/moonshot/server/global/common/model/Period.java
+++ b/src/main/java/org/moonshot/server/global/common/model/Period.java
@@ -21,4 +21,7 @@ public class Period {
     @Column(nullable = false)
     private LocalDateTime expireAt;
 
+    public static Period of(LocalDateTime startAt, LocalDateTime expireAt) {
+        return new Period(startAt, expireAt);
+    }
 }

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -27,6 +27,7 @@ public enum ErrorType {
      * 404 NOT FOUND
      */
     NOT_FOUND_USER_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    NOT_FOUND_OBJECTIVE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Objective입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 확장자입니다."),
     ACTIVE_OBJECTIVE_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Objective 개수를 초과하였습니다"),
     KEY_RESULT_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Objective 개수를 초과하였습니다"),
+    INVALID_KEY_RESULT_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -20,10 +20,13 @@ public enum ErrorType {
     INVALID_HTTP_REQUEST(HttpStatus.BAD_REQUEST, "허용되지 않는 문자열이 입력되었습니다."),
     INVALID_HTTP_METHOD(HttpStatus.BAD_REQUEST, "지원되지 않는 HTTP method 요청입니다."),
     INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 확장자입니다."),
+    ACTIVE_OBJECTIVE_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Objective 개수를 초과하였습니다"),
+    KEY_RESULT_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Objective 개수를 초과하였습니다"),
 
     /**
      * 404 NOT FOUND
      */
+    NOT_FOUND_USER_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -18,7 +18,8 @@ public enum SuccessType {
     /**
      * 201 CREATED
      */
-    POST_NOTIFY_IMAGE_SAVE_SUCCESS(HttpStatus.CREATED, "Presigned Url을 통해 이미지 생성을 성공하였습니다.");
+    POST_NOTIFY_IMAGE_SAVE_SUCCESS(HttpStatus.CREATED, "Presigned Url을 통해 이미지 생성을 성공하였습니다."),
+    POST_OKR_SUCCESS(HttpStatus.CREATED, "O-KR을 생성을 성공하였습니다.");
 
     /**
      * 204 NO CONTENT

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -19,11 +19,14 @@ public enum SuccessType {
      * 201 CREATED
      */
     POST_NOTIFY_IMAGE_SAVE_SUCCESS(HttpStatus.CREATED, "Presigned Url을 통해 이미지 생성을 성공하였습니다."),
-    POST_OKR_SUCCESS(HttpStatus.CREATED, "O-KR을 생성을 성공하였습니다.");
+    POST_OKR_SUCCESS(HttpStatus.CREATED, "O-KR을 생성을 성공하였습니다."),
+    POST_KEY_RESULT_SUCCESS(HttpStatus.CREATED, "KeyResult 생성을 성공하였습니다."),
 
     /**
      * 204 NO CONTENT
      */
+    DELETE_KEY_RESULT_SUCCESS(HttpStatus.NO_CONTENT, "KeyResult 삭제를 성공하였습니다."),
+    DELETE_OBJECTIVE_SUCCESS(HttpStatus.NO_CONTENT, "Objective 삭제를 성공하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
@@ -23,7 +23,8 @@ public class SecurityConfig {
             "/login/**",
             "/",
             "/actuator/health",
-            "/v1/image"
+            "/v1/image",
+            "/v1/okr"
     };
 
     private final MoonshotExceptionHandler moonshotExceptionHandler;

--- a/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
             "/actuator/health",
             "/v1/image",
             "/v1/objective",
-            "/v1/key-result"
+            "/v1/key-result",
             "/error",
             "/swagger-ui/**",
             "/swagger-resources/**",

--- a/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
             "/",
             "/actuator/health",
             "/v1/image",
-            "/v1/objective"
+            "/v1/objective",
+            "/v1/key-result"
     };
 
     private final MoonshotExceptionHandler moonshotExceptionHandler;

--- a/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
             "/",
             "/actuator/health",
             "/v1/image",
-            "/v1/okr"
+            "/v1/objective"
     };
 
     private final MoonshotExceptionHandler moonshotExceptionHandler;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,3 +35,5 @@ logging:
   discord:
     webhook-uri: ${DISCORD_WEBHOOK_URI}
   config: classpath:logback-dev.xml
+  level:
+    org.springframework.security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+
+
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -35,3 +37,5 @@ aws:
 
 logging:
   config: classpath:logback-local.xml
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #24 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- ObjectiveController, KeyResultController를 구현하여 해당 엔티티에 맞는 API를 구현하였음.
- Objective 생성 API는 요구사항에 맞게 최소 1개 이상의 KeyResult를 보유해야 해서 Dto를 통해 해당 데이터를 받고 ObjectiveService에서 Objective를 영속화 한 이후 KeyResultService에 요청하여 관련 KeyResult와 Task를 생성하도록 하였음. (추후 Task는 TaskService를 통해 분리할 수도 있음)
- KeyResultController에서는 KeyResult와 Task를 생성하도록 하였음.
- 또한 Objective는 최대 10개, KeyResult는 Objective 당 최대 3개라는 제한을 걸어두었고, Dto에 와프 요구사항을 Spring Validation을 통해 제한을 걸어두었음. (추후 Validation message는 Constants 클래스를 통해 한곳에 모아 둘 필요성이 존재함)
- KeyResult와 Task의 순서를 보장해야 한다는 요구사항이 존재하여 order 필드를 넣고 해당 변수를 조작하는 멤버 메소드도 추가하였음.
- 필요없는 양방향 매핑을 제거하였고 User 엔티티에서 accessToken 필드도 삭제하였음.

- 또한 가장 중요한 @ColumnDefault를 통해 멤버변수를 초기화하도록 했지만 @Column(nullable = false)에 막혀 엔티티 영속화 시 Exception이 발생하였음. 이를 @DynamicInsert를 이용하여 DB에서 레코드를 생성하도록 하여 예외를 없앴고 또한 두 어노테이션을 모두 사용하는 경우 @Column의 columnDefinition 옵션을 통하여 기본 값을 지정하도록 하였음.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->

[JPA Bulk Inserting]
[[spring batch jpa 환경에서 ID 생성전략에 따른 bulk insert 하는법](https://velog.io/@rainmaker007/spring-batch-jpa-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-ID-%EC%83%9D%EC%84%B1%EC%A0%84%EB%9E%B5%EC%97%90-%EB%94%B0%EB%A5%B8-bulk-insert-%ED%95%98%EB%8A%94%EB%B2%95)]

[[Batch Insert 성능 향상기 1편 - With JPA - Yun Blog | 기술 블로그](https://cheese10yun.github.io/jpa-batch-insert/)]

하지만 우리의 ID 생성 전략은 IDENTITY이기 때문에 id의 순서를 dbms를 통해 받아오고 저장을 해야 하므로 bulk inserting이 불가능하다. 이를 해결하기 위해서 sequence를 사용하는 방법이나 kotlin에서는 exposed라는 라이브러리가 있다.

[@DynamicInsert]
[[@DynamicInsert와 @DynamicUpdate - 인프런](https://www.inflearn.com/questions/355968/dynamicinsert%EC%99%80-dynamicupdate)]

[JPA Validation List 검증 문제]
[[Spring Request 데이터를 List 형태로 받으면 @Valid 체크가 안되는 현상 해결 방법](https://d-life93.tistory.com/416)]