### PR TITLE
[Feat] #28 - KeyResult PATCH API 개발

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/controller/KeyResultController.java
@@ -2,12 +2,15 @@ package org.moonshot.server.domain.keyresult.controller;
 
 import static org.moonshot.server.global.common.response.SuccessType.*;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultDeleteRequestDto;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultModifyRequestDto;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.global.common.response.ApiResponse;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,15 +24,21 @@ public class KeyResultController {
     private final KeyResultService keyResultService;
 
     @PostMapping
-    public ApiResponse<?> createKeyResult(@RequestBody KeyResultCreateRequestDto request) {
+    public ApiResponse<?> createKeyResult(@RequestBody @Valid KeyResultCreateRequestDto request) {
         keyResultService.createKeyResult(request);
         return ApiResponse.success(POST_KEY_RESULT_SUCCESS);
     }
 
     @DeleteMapping
-    public ApiResponse<?> deleteKeyResult(@RequestBody KeyResultDeleteRequestDto request) {
+    public ApiResponse<?> deleteKeyResult(@RequestBody @Valid KeyResultDeleteRequestDto request) {
         keyResultService.deleteKeyResult(request.keyResultIds());
         return ApiResponse.success(DELETE_KEY_RESULT_SUCCESS);
+    }
+
+    @PatchMapping
+    public ApiResponse<?> modifyKeyResult(@RequestBody @Valid KeyResultModifyRequestDto request) {
+        keyResultService.modifyKeyResult(request);
+        return ApiResponse.success(PATCH_KEY_RESULT_SUCCESS);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.hibernate.validator.constraints.Range;
+import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record KeyResultCreateRequestDto(
@@ -23,6 +24,7 @@ public record KeyResultCreateRequestDto(
         @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
         Short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
+        @ValidTargetNumber
         Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record KeyResultCreateRequestDto(
@@ -19,9 +20,10 @@ public record KeyResultCreateRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
-        short idx,
+        @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
+        Short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
-        int target,
+        Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,
         @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestDto.java
@@ -1,10 +1,8 @@
 package org.moonshot.server.domain.keyresult.dto.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.hibernate.validator.constraints.Range;
 import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.hibernate.validator.constraints.Range;
 import org.moonshot.server.domain.objective.dto.request.TaskCreateRequestDto;
+import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record KeyResultCreateRequestInfoDto(
@@ -23,7 +24,7 @@ public record KeyResultCreateRequestInfoDto(
         @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
         Short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
-        @Min(value = 1000, message = "목표 수치는 1000단위로 입력할 수 있습니다.")
+        @ValidTargetNumber
         Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -1,10 +1,12 @@
 package org.moonshot.server.domain.keyresult.dto.request;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.hibernate.validator.constraints.Range;
 import org.moonshot.server.domain.objective.dto.request.TaskCreateRequestDto;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -18,9 +20,11 @@ public record KeyResultCreateRequestInfoDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
-        short idx,
+        @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
+        Short idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
-        int target,
+        @Min(value = 1000, message = "목표 수치는 1000단위로 입력할 수 있습니다.")
+        Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,
         @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -1,7 +1,6 @@
 package org.moonshot.server.domain.keyresult.dto.request;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
@@ -1,10 +1,9 @@
 package org.moonshot.server.domain.keyresult.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
-import org.hibernate.validator.constraints.Range;
+import org.moonshot.server.domain.keyresult.model.KRState;
 import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -18,6 +17,7 @@ public record KeyResultModifyRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @ValidTargetNumber
-        Integer target
+        Integer target,
+        KRState state
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
@@ -5,11 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import org.hibernate.validator.constraints.Range;
+import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record KeyResultModifyRequestDto(
-        @NotNull(message = "수정할 KeyResult의 Objective Id를 입력해주세요.")
-        Long objectiveId,
         @NotNull(message = "수정할 KeyResult Id를 입력해주세요")
         Long keyResultId,
         @Size(min = 1, max = 30, message = "KR은 30자 이하여야 합니다.")
@@ -18,9 +17,7 @@ public record KeyResultModifyRequestDto(
         LocalDateTime startAt,
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
-        @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
-        Short idx,
-        @Min(value = 1000, message = "목표 수치는 1000단위로 입력할 수 있습니다.")
+        @ValidTargetNumber
         Integer target
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/dto/request/KeyResultModifyRequestDto.java
@@ -1,0 +1,26 @@
+package org.moonshot.server.domain.keyresult.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record KeyResultModifyRequestDto(
+        @NotNull(message = "수정할 KeyResult의 Objective Id를 입력해주세요.")
+        Long objectiveId,
+        @NotNull(message = "수정할 KeyResult Id를 입력해주세요")
+        Long keyResultId,
+        @Size(min = 1, max = 30, message = "KR은 30자 이하여야 합니다.")
+        String title,
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime startAt,
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime expireAt,
+        @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
+        Short idx,
+        @Min(value = 1000, message = "목표 수치는 1000단위로 입력할 수 있습니다.")
+        Integer target
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNotFoundException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.keyresult.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class KeyResultNotFoundException extends MoonshotException {
+    public KeyResultNotFoundException() {
+        super(ErrorType.NOT_FOUND_KEY_RESULT_ERROR);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/exception/KeyResultNotFoundException.java
@@ -4,7 +4,9 @@ import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
 
 public class KeyResultNotFoundException extends MoonshotException {
+
     public KeyResultNotFoundException() {
         super(ErrorType.NOT_FOUND_KEY_RESULT_ERROR);
     }
+
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -32,10 +32,10 @@ public class KeyResult {
     private Period period;
 
     @Column(nullable = false)
-    private int target;
+    private Integer target;
 
     @Column(nullable = false)
-    private short idx;
+    private Short idx;
 
     @Column(nullable = false)
     private String metric;

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -67,4 +67,9 @@ public class KeyResult {
     public void modifyTarget(Integer target) {
         this.target = target;
     }
+
+    public void modifyState(KRState state) {
+        this.state = state;
+    }
+
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -1,16 +1,10 @@
 package org.moonshot.server.domain.keyresult.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
-import org.moonshot.server.domain.log.model.Log;
-import org.moonshot.server.domain.task.model.Task;
 import org.moonshot.server.domain.objective.model.Objective;
 import org.moonshot.server.global.common.model.Period;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/model/KeyResult.java
@@ -57,4 +57,20 @@ public class KeyResult {
     public void incrementIdx() {
         ++this.idx;
     }
+
+    public void modifyTitle(String title) {
+        this.title = title;
+    }
+
+    public void modifyPeriod(Period period) {
+        this.period = period;
+    }
+
+    public void modifyIdx(Short idx) {
+        this.idx = idx;
+    }
+
+    public void modifyTarget(Integer target) {
+        this.target = target;
+    }
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/repository/KeyResultRepository.java
@@ -1,14 +1,20 @@
 package org.moonshot.server.domain.keyresult.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.objective.model.Objective;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
 
     Long countAllByObjective(Objective objective);
     List<KeyResult> findByIdIn(List<Long> ids);
     List<KeyResult> findAllByObjective(Objective objective);
+    List<KeyResult> findAllByObjectiveId(Long objectiveId);
+    @Query("select kr from KeyResult kr join fetch kr.objective where kr.id = :keyResultId")
+    Optional<KeyResult> findKeyResultAndObjective(@Param("keyResultId") Long keyResultId);
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -95,9 +95,7 @@ public class KeyResultService {
     }
 
     private void cascadeDelete(List<KeyResult> krList) {
-        krList.forEach((kr) -> {
-            taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResult(kr));
-        });
+        krList.forEach((kr) -> taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResult(kr)));
         keyResultRepository.deleteAllInBatch(krList);
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestInfoDto;
+import org.moonshot.server.domain.keyresult.dto.request.KeyResultModifyRequestDto;
 import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidPositionException;
+import org.moonshot.server.domain.keyresult.exception.KeyResultNotFoundException;
 import org.moonshot.server.domain.keyresult.exception.KeyResultNumberExceededException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
@@ -27,6 +29,10 @@ public class KeyResultService {
     private final ObjectiveRepository objectiveRepository;
     private final KeyResultRepository keyResultRepository;
     private final TaskRepository taskRepository;
+
+    //TODO
+    // 여기 모든 로직에 User 관련 기능이 추가된 이후
+    // KeyResult의 소유자인지 확인하는 절차를 추가해야 함.
 
     @Transactional
     public void createInitKRWithObjective(Objective objective, List<KeyResultCreateRequestInfoDto> requests) {
@@ -93,6 +99,29 @@ public class KeyResultService {
             taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResult(kr));
         });
         keyResultRepository.deleteAllInBatch(krList);
+    }
+
+    @Transactional
+    public void modifyKeyResult(KeyResultModifyRequestDto request) {
+        KeyResult keyResult = keyResultRepository.findById(request.keyResultId())
+                .orElseThrow(KeyResultNotFoundException::new);
+
+        if (request.title() != null) {
+            keyResult.modifyTitle(request.title());
+        }
+        if (request.startAt() != null) {
+            if (request.expireAt() != null) {
+                keyResult.modifyPeriod(Period.of(request.startAt(), request.expireAt()));
+            }
+            keyResult.modifyPeriod(Period.of(request.startAt(), keyResult.getPeriod().getExpireAt()));
+        } else {
+            if (request.expireAt() != null) {
+                keyResult.modifyPeriod(Period.of(keyResult.getPeriod().getStartAt(), request.expireAt()));
+            }
+        }
+        if (request.target() != null) {
+            keyResult.modifyTarget(request.target());
+        }
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -120,6 +120,9 @@ public class KeyResultService {
         if (request.target() != null) {
             keyResult.modifyTarget(request.target());
         }
+        if (request.state() != null) {
+            keyResult.modifyState(request.state());
+        }
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyResult/service/KeyResultService.java
@@ -1,5 +1,7 @@
 package org.moonshot.server.domain.keyresult.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
@@ -107,15 +109,10 @@ public class KeyResultService {
         if (request.title() != null) {
             keyResult.modifyTitle(request.title());
         }
-        if (request.startAt() != null) {
-            if (request.expireAt() != null) {
-                keyResult.modifyPeriod(Period.of(request.startAt(), request.expireAt()));
-            }
-            keyResult.modifyPeriod(Period.of(request.startAt(), keyResult.getPeriod().getExpireAt()));
-        } else {
-            if (request.expireAt() != null) {
-                keyResult.modifyPeriod(Period.of(keyResult.getPeriod().getStartAt(), request.expireAt()));
-            }
+        if (request.startAt() != null || request.expireAt() != null) {
+            LocalDateTime newStartAt = (request.startAt() != null) ? request.startAt() : keyResult.getPeriod().getStartAt();
+            LocalDateTime newExpireAt = (request.expireAt() != null) ? request.expireAt() : keyResult.getPeriod().getExpireAt();
+            keyResult.modifyPeriod(Period.of(newStartAt, newExpireAt));
         }
         if (request.target() != null) {
             keyResult.modifyTarget(request.target());

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
@@ -17,7 +17,7 @@ public record KRCreateRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
-        int target,
+        Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,
         @NotNull(message = "KR 목표의 이전 수식을 입력해주세요.")

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/KRCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.moonshot.server.global.common.model.validator.ValidTargetNumber;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record KRCreateRequestDto(
@@ -17,6 +18,7 @@ public record KRCreateRequestDto(
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime expireAt,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
+        @ValidTargetNumber
         Integer target,
         @NotNull(message = "KR 목표 수치의 단위를 입력해주세요.")
         String metric,

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/TaskCreateRequestDto.java
@@ -2,11 +2,13 @@ package org.moonshot.server.domain.objective.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 
 public record TaskCreateRequestDto(
         @Size(min = 1, max = 30, message = "Task는 30자 이하여야 합니다.")
         String title,
         @NotNull(message = "KR 순서를 입력해주세요")
-        short idx
+        @Range(min = 0, max = 2, message = "Task의 순서는 0부터 2까지로 설정할 수 있습니다.")
+        Short idx
 ) {
 }

--- a/src/main/java/org/moonshot/server/global/common/exception/MoonshotControllerAdvice.java
+++ b/src/main/java/org/moonshot/server/global/common/exception/MoonshotControllerAdvice.java
@@ -1,14 +1,13 @@
 package org.moonshot.server.global.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintDefinitionException;
 import jakarta.validation.UnexpectedTypeException;
 import lombok.extern.slf4j.Slf4j;
 import org.moonshot.server.global.common.response.ApiResponse;
 import org.moonshot.server.global.common.response.ErrorType;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -77,6 +76,12 @@ public class MoonshotControllerAdvice {
     protected ApiResponse<?> handlerHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
         log.error(e.getMessage(), e);
         return ApiResponse.error(ErrorType.INVALID_HTTP_METHOD);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ConstraintDefinitionException.class)
+    protected ApiResponse<?> handlerConstraintDefinitionException(final ConstraintDefinitionException e) {
+        return ApiResponse.error(ErrorType.INVALID_HTTP_REQUEST, e.toString());
     }
 
     /**

--- a/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
@@ -2,7 +2,6 @@ package org.moonshot.server.global.common.model.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
@@ -2,10 +2,19 @@ package org.moonshot.server.global.common.model.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TargetNumberValidator implements ConstraintValidator<ValidTargetNumber, Integer> {
+
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
-        return (value == null) || (value != null && value > 0 && value % 1000 == 0);
+        if (value == null) {
+            return true;
+        } else {
+            return value > 0 && value % 1000 == 0;
+        }
     }
+
 }

--- a/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
@@ -1,0 +1,11 @@
+package org.moonshot.server.global.common.model.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class TargetNumberValidator implements ConstraintValidator<ValidTargetNumber, Integer> {
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return (value == null) || (value != null && value > 0 && value % 1000 == 0);
+    }
+}

--- a/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
@@ -4,7 +4,6 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class TargetNumberValidator implements ConstraintValidator<ValidTargetNumber, Integer> {
 
     @Override

--- a/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
@@ -6,9 +6,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Constraint(validatedBy = TargetNumberValidator.class)
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TargetNumberValidator.class)
 public @interface ValidTargetNumber {
 
     String message() default "목표치는 1000단위로 입력해야 합니다.";

--- a/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
@@ -7,10 +7,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = TargetNumberValidator.class)
-@Target({ElementType.FIELD})
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidTargetNumber {
 
     String message() default "목표치는 1000단위로 입력해야 합니다.";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
 
 }

--- a/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/ValidTargetNumber.java
@@ -1,0 +1,16 @@
+package org.moonshot.server.global.common.model.validator;
+
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = TargetNumberValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidTargetNumber {
+
+    String message() default "목표치는 1000단위로 입력해야 합니다.";
+
+}

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -3,7 +3,6 @@ package org.moonshot.server.global.common.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties.Http;
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -29,6 +29,7 @@ public enum ErrorType {
      */
     NOT_FOUND_USER_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NOT_FOUND_OBJECTIVE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Objective입니다."),
+    NOT_FOUND_KEY_RESULT_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 KeyResult입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -25,6 +25,7 @@ public enum SuccessType {
     /**
      * 204 NO CONTENT
      */
+    PATCH_KEY_RESULT_SUCCESS(HttpStatus.NO_CONTENT, "KeyResult 수정을 성공하였습니다."),
     DELETE_KEY_RESULT_SUCCESS(HttpStatus.NO_CONTENT, "KeyResult 삭제를 성공하였습니다."),
     DELETE_OBJECTIVE_SUCCESS(HttpStatus.NO_CONTENT, "Objective 삭제를 성공하였습니다.");
 


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #28 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- KeyResult의 내용을 수정하는 PATCH API 개발
- 해당 API로 변경 가능한 사항은 Title, startAt, expireAt(기간), target(목표치), KRState(상태)
- 해당 API에 순서변경을 넣지 않은 이유는 순서 변경에 처리되는 로직이 방대하고 해당 API가 적용되는 시점이 다르기 때문에 분리해도 된다고 판단하였음.
- DTO에 담겨있는 short idx나 int target 변수는 primitive type이기 때문에 null check가 불가능하여 Entity와 Dto에 들어가는 타입을 각각 Short, Integer와 같은 Wrapper type으로 변경하였음.
- target은 1000단위로 입력해야 되는 요구사항이 있어서 해당 사항을 체크하는 Custom Validator (@ValidTargetNumber) 어노테이션 및 Validator 구현하였음.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->

[(Spring Boot) Custom Validator 적용하는 방법, 단일 및 다중 필드](https://wildeveloperetrain.tistory.com/157)
