### PR TITLE
[Feat] #37 - 닉네임 설정, 프로필 수정 API 개발

### DIFF
--- a/src/main/java/org/moonshot/server/domain/user/controller/UserController.java
+++ b/src/main/java/org/moonshot/server/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package org.moonshot.server.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.user.dto.request.UserInfoRequest;
+import org.moonshot.server.domain.user.dto.response.UserInfoResponse;
 import org.moonshot.server.domain.user.dto.request.SocialLoginRequest;
 import org.moonshot.server.domain.user.dto.response.SocialLoginResponse;
 import org.moonshot.server.domain.user.service.UserService;
@@ -41,6 +43,11 @@ public class UserController {
     public ApiResponse<?> withdrawal(Principal principal) {
         userService.withdrawal(JwtTokenProvider.getUserIdFromPrincipal(principal));
         return ApiResponse.success(SuccessType.DELETE_USER_SUCCESS);
+    }
+
+    @PatchMapping("/profile")
+    public ApiResponse<UserInfoResponse> modifyProfile(Principal principal, @RequestBody UserInfoRequest userInfoRequest) {
+        return ApiResponse.success(SuccessType.PATCH_PROFILE_SUCCESS, userService.modifyProfile(JwtTokenProvider.getUserIdFromPrincipal(principal), userInfoRequest));
     }
 
 //    @GetMapping("/login/oauth2/code/kakao")

--- a/src/main/java/org/moonshot/server/domain/user/dto/request/UserInfoRequest.java
+++ b/src/main/java/org/moonshot/server/domain/user/dto/request/UserInfoRequest.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.user.dto.request;
+
+public record UserInfoRequest(
+        String nickname,
+        String description
+) {
+    public static UserInfoRequest of(String nickname, String description) {
+        return new UserInfoRequest(nickname, description);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/moonshot/server/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,14 @@
+package org.moonshot.server.domain.user.dto.response;
+
+import org.moonshot.server.domain.user.model.User;
+
+public record UserInfoResponse(
+        String nickname,
+        String description
+) {
+    public static UserInfoResponse of(User user) {
+        return new UserInfoResponse(
+                user.getNickname(),
+                user.getDescription());
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/user/model/User.java
+++ b/src/main/java/org/moonshot/server/domain/user/model/User.java
@@ -51,4 +51,8 @@ public class User {
         this.socialPlatform = socialPlatform;
     }
 
+    public void modifyNickname(String nickname) { this.nickname = nickname; }
+
+    public void modifyDescription(String description) { this.description = description; }
+
 }

--- a/src/main/java/org/moonshot/server/domain/user/model/User.java
+++ b/src/main/java/org/moonshot/server/domain/user/model/User.java
@@ -28,10 +28,8 @@ public class User {
     @Column(nullable = false)
     private String profileImage;
 
-    @Column(nullable = false)
     private String email;
 
-    @Column(unique = true)
     private String nickname;
 
     private String description;

--- a/src/main/java/org/moonshot/server/domain/user/service/UserService.java
+++ b/src/main/java/org/moonshot/server/domain/user/service/UserService.java
@@ -2,7 +2,9 @@ package org.moonshot.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.user.dto.request.SocialLoginRequest;
+import org.moonshot.server.domain.user.dto.request.UserInfoRequest;
 import org.moonshot.server.domain.user.dto.response.SocialLoginResponse;
+import org.moonshot.server.domain.user.dto.response.UserInfoResponse;
 import org.moonshot.server.domain.user.dto.response.google.GoogleInfoResponse;
 import org.moonshot.server.domain.user.dto.response.google.GoogleTokenResponse;
 import org.moonshot.server.domain.user.dto.response.kakao.KakaoTokenResponse;
@@ -148,6 +150,19 @@ public class UserService {
         User user =  userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         user.modifySocialPlatform(SocialPlatform.WITHDRAWAL);
+    }
+
+    @Transactional
+    public UserInfoResponse modifyProfile(Long userId, UserInfoRequest request) {
+        User user =  userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        if (request.nickname() != null) {
+            user.modifyNickname(request.nickname());
+        }
+        if (request.description() != null) {
+            user.modifyDescription(request.description());
+        }
+        return UserInfoResponse.of(user);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/user/service/UserService.java
+++ b/src/main/java/org/moonshot/server/domain/user/service/UserService.java
@@ -85,7 +85,6 @@ public class UserService {
                             .profileImage(userResponse.picture())
                             .email(userResponse.email())
                             .build());
-
             user = newUser;
         } else {
             user = findUser.get();
@@ -116,9 +115,8 @@ public class UserService {
                             .socialPlatform(request.socialPlatform())
                             .name(userResponse.kakaoAccount().profile().nickname())
                             .profileImage(userResponse.kakaoAccount().profile().profileImageUrl())
-                            .email("")
+                            .email(null)
                             .build());
-
             user = newUser;
         } else {
             user = findUser.get();

--- a/src/main/java/org/moonshot/server/global/auth/filter/MoonshotExceptionHandler.java
+++ b/src/main/java/org/moonshot/server/global/auth/filter/MoonshotExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class MoonshotExceptionHandler implements AccessDeniedHandler, AuthenticationEntryPoint {
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
@@ -25,4 +26,5 @@ public class MoonshotExceptionHandler implements AccessDeniedHandler, Authentica
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
     }
+
 }

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -17,6 +17,7 @@ public enum SuccessType {
     POST_LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
     POST_REISSUE_SUCCESS(HttpStatus.OK, "엑세스 토큰 재발급에 성공하였습니다."),
     POST_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공하였습니다."),
+    PATCH_PROFILE_SUCCESS(HttpStatus.OK, "사용자 프로필 업데이트에 성공하였습니다."),
 
     /**
      * 201 CREATED


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #37 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 회원가입 후 닉네임 설정 API
<img width="1079" alt="스크린샷 2024-01-08 오전 12 35 18" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/e3e70ae5-78fe-4432-99f5-49563f728e44">
- 프로필 수정 API
<img width="1077" alt="스크린샷 2024-01-08 오전 12 31 47" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/e65ca2a5-5bcd-4ddb-8b65-8f6aa11a3d9b">

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- User엔티티에서 닉네임은 중복 허용으로 변경했고, 카카오에서 이메일 받아오지 못하는 이슈로 email nullable 가능하게 해두었습니다!
- 앱잼에서는 회원가입 후 닉네임 설정 API 로만 사용될 예정입니다! 프로필 이미지 수정은 앱잼 이후에 구현 예정입니다!
- 닉네임 설정 시에는 requestBody에 nickname만 넣고, 프로필 설정 시에는 nickname, description만 넣으면 됩니다!
