### PR TITLE
[Add] #42 - Task, KeyResult 순서 변경 API

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyresult/dto/request/KeyResultCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/dto/request/KeyResultCreateRequestDto.java
@@ -20,7 +20,7 @@ public record KeyResultCreateRequestDto(
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
         @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
-        Short idx,
+        Integer idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
         @ValidTargetNumber
         Integer target,

--- a/src/main/java/org/moonshot/server/domain/keyresult/dto/request/KeyResultCreateRequestInfoDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/dto/request/KeyResultCreateRequestInfoDto.java
@@ -21,7 +21,7 @@ public record KeyResultCreateRequestInfoDto(
         LocalDateTime expireAt,
         @NotNull(message = "KR의 순서를 입력해주세요.")
         @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
-        Short idx,
+        Integer idx,
         @NotNull(message = "KR 목표 수치를 입력해주세요.")
         @ValidTargetNumber
         Integer target,

--- a/src/main/java/org/moonshot/server/domain/keyresult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/model/KeyResult.java
@@ -29,7 +29,7 @@ public class KeyResult {
     private Integer target;
 
     @Column(nullable = false)
-    private Short idx;
+    private Integer idx;
 
     @Column(nullable = false)
     private String metric;
@@ -52,6 +52,10 @@ public class KeyResult {
         ++this.idx;
     }
 
+    public void decreaseIdx() {
+        --this.idx;
+    }
+
     public void modifyTitle(String title) {
         this.title = title;
     }
@@ -60,7 +64,7 @@ public class KeyResult {
         this.period = period;
     }
 
-    public void modifyIdx(Short idx) {
+    public void modifyIdx(Integer idx) {
         this.idx = idx;
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.objective.model.Objective;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,8 +14,14 @@ public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
     Long countAllByObjective(Objective objective);
     List<KeyResult> findByIdIn(List<Long> ids);
     List<KeyResult> findAllByObjective(Objective objective);
+    List<KeyResult> findAllByObjectiveOrderByIdx(Objective objective);
     List<KeyResult> findAllByObjectiveId(Long objectiveId);
     @Query("select kr from KeyResult kr join fetch kr.objective join fetch kr.objective.user where kr.id = :keyResultId")
     Optional<KeyResult> findKeyResultAndObjective(@Param("keyResultId") Long keyResultId);
-
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE KeyResult kr SET kr.idx = kr.idx + 1 WHERE kr.idx >= :lBound AND kr.idx < :uBound AND kr.objective.id = :objectiveId AND kr.id != :targetId")
+    void bulkUpdateIdxIncrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("objectiveId") Long objectiveId, @Param("targetId") Long targetId);
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE KeyResult kr SET kr.idx = kr.idx - 1 WHERE kr.idx >= :lBound AND kr.idx <= :uBound AND kr.objective.id = :objectiveId AND kr.id != :targetId")
+    void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("objectiveId") Long objectiveId, @Param("targetId") Long targetId);
 }

--- a/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
@@ -24,4 +24,5 @@ public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE KeyResult kr SET kr.idx = kr.idx - 1 WHERE kr.idx >= :lBound AND kr.idx <= :uBound AND kr.objective.id = :objectiveId AND kr.id != :targetId")
     void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("objectiveId") Long objectiveId, @Param("targetId") Long targetId);
+
 }

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -158,7 +158,6 @@ public class KeyResultService implements IndexService {
         if (prevIdx.equals(request.idx())) {
             return;
         }
-        List<KeyResult> krList = keyResultRepository.findAllByObjectiveOrderByIdx(keyResult.getObjective());
 
         keyResult.modifyIdx(request.idx());
         if (prevIdx < request.idx()) {

--- a/src/main/java/org/moonshot/server/domain/log/model/Log.java
+++ b/src/main/java/org/moonshot/server/domain/log/model/Log.java
@@ -2,11 +2,8 @@ package org.moonshot.server.domain.log.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
-import org.moonshot.server.domain.user.model.SocialPlatform;
-import org.moonshot.server.domain.user.model.User;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/moonshot/server/domain/objective/controller/IndexController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/IndexController.java
@@ -1,0 +1,31 @@
+package org.moonshot.server.domain.objective.controller;
+
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
+import org.moonshot.server.domain.objective.model.IndexService;
+import org.moonshot.server.domain.objective.service.IndexTargetProvider;
+import org.moonshot.server.global.auth.jwt.JwtTokenProvider;
+import org.moonshot.server.global.common.response.ApiResponse;
+import org.moonshot.server.global.common.response.SuccessType;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/index")
+public class IndexController {
+
+    private final IndexTargetProvider indexTargetProvider;
+
+    @PatchMapping
+    public ApiResponse<?> modifyIdx(Principal principal, @RequestBody @Valid ModifyIndexRequestDto request) {
+        IndexService indexService = indexTargetProvider.getIndexService(request.target());
+        indexService.modifyIdx(request, JwtTokenProvider.getUserIdFromPrincipal(principal));
+        return ApiResponse.success(SuccessType.PATCH_TARGET_INDEX_SUCCESS);
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/ModifyIndexRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/ModifyIndexRequestDto.java
@@ -1,0 +1,16 @@
+package org.moonshot.server.domain.objective.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+import org.moonshot.server.domain.objective.model.IndexTarget;
+
+public record ModifyIndexRequestDto(
+        @NotNull(message = "대상의 ID를 입력해주세요.")
+        Long id,
+        @NotNull(message = "대상을 지정해주세요.")
+        IndexTarget target,
+        @NotNull(message = "대상의 이동할 위치 값을 입력하세요.")
+        @Range(min = 0, max = 2, message = "순서는 0부터 2까지로 설정할 수 있습니다.")
+        Integer idx
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/objective/model/IndexService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/IndexService.java
@@ -3,5 +3,7 @@ package org.moonshot.server.domain.objective.model;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
 
 public interface IndexService {
+
     void modifyIdx(ModifyIndexRequestDto request, Long userId);
+
 }

--- a/src/main/java/org/moonshot/server/domain/objective/model/IndexService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/IndexService.java
@@ -1,0 +1,7 @@
+package org.moonshot.server.domain.objective.model;
+
+import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
+
+public interface IndexService {
+    void modifyIdx(ModifyIndexRequestDto request, Long userId);
+}

--- a/src/main/java/org/moonshot/server/domain/objective/model/IndexTarget.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/IndexTarget.java
@@ -1,0 +1,16 @@
+package org.moonshot.server.domain.objective.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum IndexTarget {
+
+    KEY_RESULT("keyResult"),
+    TASK("task");
+
+    private final String value;
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
@@ -1,0 +1,30 @@
+package org.moonshot.server.domain.objective.service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.keyresult.service.KeyResultService;
+import org.moonshot.server.domain.objective.model.IndexService;
+import org.moonshot.server.domain.objective.model.IndexTarget;
+import org.moonshot.server.domain.task.service.TaskService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IndexTargetProvider {
+
+    private static final Map<IndexTarget, IndexService> indexServiceMap = new HashMap<>();
+    private final KeyResultService keyResultService;
+    private final TaskService taskService;
+
+    @PostConstruct
+    void initIndexServiceMap() {
+        indexServiceMap.put(IndexTarget.KEY_RESULT, keyResultService);
+        indexServiceMap.put(IndexTarget.TASK, taskService);
+    }
+
+    public IndexService getIndexService(IndexTarget indexTarget) {
+        return indexServiceMap.get(indexTarget);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
@@ -27,4 +27,5 @@ public class IndexTargetProvider {
     public IndexService getIndexService(IndexTarget indexTarget) {
         return indexServiceMap.get(indexTarget);
     }
+
 }

--- a/src/main/java/org/moonshot/server/domain/task/dto/request/TaskCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/task/dto/request/TaskCreateRequestDto.java
@@ -9,6 +9,6 @@ public record TaskCreateRequestDto(
         String title,
         @NotNull(message = "KR 순서를 입력해주세요")
         @Range(min = 0, max = 2, message = "Task의 순서는 0부터 2까지로 설정할 수 있습니다.")
-        Short idx
+        Integer idx
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/task/dto/request/TaskSingleCreateRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/task/dto/request/TaskSingleCreateRequestDto.java
@@ -11,6 +11,6 @@ public record TaskSingleCreateRequestDto(
         String title,
         @NotNull(message = "KR 순서를 입력해주세요")
         @Range(min = 0, max = 2, message = "KeyResult의 순서는 0부터 2까지로 설정할 수 있습니다.")
-        Short idx
+        Integer idx
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/task/exception/TaskNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/task/exception/TaskNotFoundException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.task.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class TaskNotFoundException extends MoonshotException {
+    public TaskNotFoundException() {
+        super(ErrorType.NOT_FOUND_TASK_ERROR);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/task/exception/TaskNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/task/exception/TaskNotFoundException.java
@@ -4,7 +4,9 @@ import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
 
 public class TaskNotFoundException extends MoonshotException {
+
     public TaskNotFoundException() {
         super(ErrorType.NOT_FOUND_TASK_ERROR);
     }
+
 }

--- a/src/main/java/org/moonshot/server/domain/task/model/Task.java
+++ b/src/main/java/org/moonshot/server/domain/task/model/Task.java
@@ -20,7 +20,7 @@ public class Task {
     private String title;
 
     @Column(nullable = false)
-    private short idx;
+    private Integer idx;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "key_result_id")
@@ -29,4 +29,9 @@ public class Task {
     public void incrementIdx() {
         ++this.idx;
     }
+
+    public void modifyIdx(Integer idx) {
+        this.idx = idx;
+    }
+
 }

--- a/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
@@ -1,13 +1,25 @@
 package org.moonshot.server.domain.task.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.task.model.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
     List<Task> findAllByKeyResult(KeyResult keyResult);
     List<Task> findAllByKeyResultOrderByIdx(KeyResult keyResult);
+    @Query("select t from Task t join fetch t.keyResult kr join fetch kr.objective obj join fetch obj.user u where t.id = :taskId")
+    Optional<Task> findTaskWithFetchJoin(@Param("taskId") Long taskId);
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE Task t SET t.idx = t.idx + 1 WHERE t.idx >= :lBound AND t.idx < :uBound AND t.keyResult.id = :keyResultId AND t.id != :targetId")
+    void bulkUpdateTaskIdxIncrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("keyResultId") Long keyResultId, @Param("targetId") Long targetId);
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE Task t SET t.idx = t.idx - 1 WHERE t.idx >= :lBound AND t.idx <= :uBound AND t.keyResult.id = :keyResultId AND t.id != :targetId")
+    void bulkUpdateTaskIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("keyResultId") Long keyResultId, @Param("targetId") Long targetId);
 
 }

--- a/src/main/java/org/moonshot/server/domain/task/service/TaskService.java
+++ b/src/main/java/org/moonshot/server/domain/task/service/TaskService.java
@@ -87,4 +87,5 @@ public class TaskService implements IndexService {
             taskRepository.bulkUpdateTaskIdxIncrease(request.idx(), prevIdx, task.getKeyResult().getId(), task.getId());
         }
     }
+
 }

--- a/src/main/java/org/moonshot/server/domain/task/service/TaskService.java
+++ b/src/main/java/org/moonshot/server/domain/task/service/TaskService.java
@@ -5,11 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidPositionException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
+import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
+import org.moonshot.server.domain.objective.model.IndexService;
 import org.moonshot.server.domain.task.dto.request.TaskCreateRequestDto;
 import org.moonshot.server.domain.task.dto.request.TaskSingleCreateRequestDto;
+import org.moonshot.server.domain.task.exception.TaskNotFoundException;
 import org.moonshot.server.domain.task.exception.TaskNumberExceededException;
 import org.moonshot.server.domain.task.model.Task;
 import org.moonshot.server.domain.task.repository.TaskRepository;
+import org.moonshot.server.domain.user.service.UserService;
 import org.moonshot.server.global.auth.exception.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class TaskService {
+public class TaskService implements IndexService {
 
     private static final int ACTIVE_TASK_NUMBER = 3;
 
     private final KeyResultRepository keyResultRepository;
     private final TaskRepository taskRepository;
+    private final UserService userService;
 
     @Transactional
     public void createTask(TaskSingleCreateRequestDto request, Long userId) {
@@ -40,7 +45,7 @@ public class TaskService {
             throw new KeyResultInvalidPositionException();
         }
 
-        for (short i = request.idx(); i < taskList.size(); i++) {
+        for (int i = request.idx(); i < taskList.size(); i++) {
             taskList.get(i).incrementIdx();
         }
 
@@ -63,4 +68,23 @@ public class TaskService {
                 .build());
     }
 
+    @Override
+    @Transactional
+    public void modifyIdx(ModifyIndexRequestDto request, Long userId) {
+        Task task = taskRepository.findTaskWithFetchJoin(request.id())
+                .orElseThrow(TaskNotFoundException::new);
+        userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);
+        Integer prevIdx = task.getIdx();
+        if (prevIdx.equals(request.idx())) {
+            return;
+        }
+        List<Task> taskList = taskRepository.findAllByKeyResult(task.getKeyResult());
+
+        task.modifyIdx(request.idx());
+        if (prevIdx < request.idx()) {
+            taskRepository.bulkUpdateTaskIdxDecrease(prevIdx + 1, request.idx(), task.getKeyResult().getId(), task.getId());
+        } else {
+            taskRepository.bulkUpdateTaskIdxIncrease(request.idx(), prevIdx, task.getKeyResult().getId(), task.getId());
+        }
+    }
 }

--- a/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
+++ b/src/main/java/org/moonshot/server/global/common/model/validator/TargetNumberValidator.java
@@ -2,7 +2,6 @@ package org.moonshot.server.global.common.model.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import lombok.extern.slf4j.Slf4j;
 
 public class TargetNumberValidator implements ConstraintValidator<ValidTargetNumber, Long> {
 

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -43,6 +43,7 @@ public enum ErrorType {
     NOT_FOUND_USER_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NOT_FOUND_OBJECTIVE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Objective입니다."),
     NOT_FOUND_KEY_RESULT_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 KeyResult입니다."),
+    NOT_FOUND_TASK_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Task입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -31,6 +31,7 @@ public enum SuccessType {
      * 204 NO CONTENT
      */
     PATCH_KEY_RESULT_SUCCESS(HttpStatus.NO_CONTENT, "KeyResult 수정을 성공하였습니다."),
+    PATCH_TARGET_INDEX_SUCCESS(HttpStatus.NO_CONTENT, "대상의 순서 수정을 성공하였습니다."),
     DELETE_KEY_RESULT_SUCCESS(HttpStatus.NO_CONTENT, "KeyResult 삭제를 성공하였습니다."),
     DELETE_OBJECTIVE_SUCCESS(HttpStatus.NO_CONTENT, "Objective 삭제를 성공하였습니다."),
     DELETE_USER_SUCCESS(HttpStatus.NO_CONTENT, "회원 탈퇴에 성공하였습니다." );


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #42 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Task, KeyResult 메인보드에서 위치를 수정하는 API 개발
- 기존 Task나 KeyResult의 위치를 변경하면 다른 엔티티의 데이터도 변경되어 최소 1개에서 최대 3개의 업데이트 쿼리가 발생하게 되는데 이런 쿼리를 한번에 bulk update로 구현하였음. (쿼리 1개로 축소)
- API Controller는 IndexController에 구현되어 있고, IndexController에서 IndexService의 구현체를 갈아끼우는 로직이 존재함. 각 구현체들은 KeyResult와 Task에 각각 구현되어 있음.
- JPQL이 파라미터를 기본적으로 int형으로 관리하기 때문에 Short와의 충돌이 발생하였음. 그래서 엔티티 Wrapper Type을 Integer로 변경하였음.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
