### PR TITLE
[Add] #46 - Objective 삭제 API

### DIFF
--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -8,6 +8,8 @@ import org.moonshot.server.domain.objective.service.ObjectiveService;
 import org.moonshot.server.global.auth.jwt.JwtTokenProvider;
 import org.moonshot.server.global.common.response.ApiResponse;
 import org.moonshot.server.global.common.response.SuccessType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +31,10 @@ public class ObjectiveController {
         return ApiResponse.success(SuccessType.POST_OKR_SUCCESS);
     }
 
-    //TODO
-    // PATCH API (목표 히스토리로 넘기기 - 상태수정)
+    @DeleteMapping("/{objectiveId}")
+    public ApiResponse<?> deleteObjective(Principal principal, @PathVariable("objectiveId") Long objectiveId) {
+        objectiveService.deleteObjective(JwtTokenProvider.getUserIdFromPrincipal(principal), objectiveId);
+        return ApiResponse.success(SuccessType.DELETE_OBJECTIVE_SUCCESS);
+    }
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -3,12 +3,14 @@ package org.moonshot.server.domain.objective.service;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
+import org.moonshot.server.domain.objective.exception.ObjectiveNotFoundException;
 import org.moonshot.server.domain.objective.exception.ObjectiveNumberExceededException;
 import org.moonshot.server.domain.objective.model.Objective;
 import org.moonshot.server.domain.objective.repository.ObjectiveRepository;
 import org.moonshot.server.domain.user.exception.UserNotFoundException;
 import org.moonshot.server.domain.user.model.User;
 import org.moonshot.server.domain.user.repository.UserRepository;
+import org.moonshot.server.global.auth.exception.AccessDeniedException;
 import org.moonshot.server.global.common.model.Period;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +43,17 @@ public class ObjectiveService {
                 .user(user).build());
 
         keyResultService.createInitKRWithObjective(newObjective, request.krList());
+    }
+
+    @Transactional
+    public void deleteObjective(Long userId, Long objectiveId) {
+        Objective objective = objectiveRepository.findObjectiveAndUserById(objectiveId)
+                .orElseThrow(ObjectiveNotFoundException::new);
+        if (!objective.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException();
+        }
+        keyResultService.deleteKeyResult(objective);
+        objectiveRepository.delete(objective);
     }
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #46 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Objective 삭제 API 구현
- Objective 삭제 후 KeyResultService의 deleteKeyResult(Objective objective); 메소드를 이용하여 deleteAllInBatch로 cascade 삭제를 대신함.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
