### PR TITLE
[Fix] #50 - TokenResponse 수정 및 만료시간 변경 / Log 생성 관련 Exception 추가

### DIFF
--- a/src/main/java/org/moonshot/server/domain/log/exception/InvalidRecordException.java
+++ b/src/main/java/org/moonshot/server/domain/log/exception/InvalidRecordException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.log.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class InvalidRecordException extends MoonshotException {
+
+    public InvalidRecordException() { super(ErrorType.INVALID_RECORD_VALUE); }
+
+}

--- a/src/main/java/org/moonshot/server/domain/log/service/LogService.java
+++ b/src/main/java/org/moonshot/server/domain/log/service/LogService.java
@@ -10,6 +10,7 @@ import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
 import org.moonshot.server.domain.log.dto.request.LogCreateRequestDto;
 import org.moonshot.server.domain.log.dto.response.LogResponseDto;
 import org.moonshot.server.domain.log.exception.InvalidLogValueException;
+import org.moonshot.server.domain.log.exception.InvalidRecordException;
 import org.moonshot.server.domain.log.model.Log;
 import org.moonshot.server.domain.log.model.LogState;
 import org.moonshot.server.domain.log.repository.LogRepository;
@@ -40,6 +41,9 @@ public class LogService {
                 .orElseThrow(KeyResultNotFoundException::new);
         if (!keyResult.getObjective().getUser().getId().equals(userId)) {
             throw new AccessDeniedException();
+        }
+        if(request.logNum() > keyResult.getTarget()) {
+            throw new InvalidRecordException();
         }
         Optional<Log> prevLog = logRepository.findLatestLogByKeyResultId(LogState.RECORD, request.keyResultId());
         long prevNum = -1;

--- a/src/main/java/org/moonshot/server/global/auth/jwt/TokenResponse.java
+++ b/src/main/java/org/moonshot/server/global/auth/jwt/TokenResponse.java
@@ -5,6 +5,6 @@ public record TokenResponse(
         String refreshToken
 ) {
     public static TokenResponse of(String accessToken, String refreshToken) {
-        return new TokenResponse(accessToken, refreshToken);
+        return new TokenResponse("Bearer " + accessToken, "Bearer " + refreshToken);
     }
 }

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -24,7 +24,7 @@ public enum ErrorType {
     INVALID_KEY_RESULT_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
     INVALID_TASK_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
     INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 이전 값보다 큰 값이 입력되어야합니다."),
-    INVALID_RECORD_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 목표값보다 작은 값이 입력되어야합니다."),
+    INVALID_RECORD_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 목표값보다 작은 값이 입력되어야 합니다."),
 
     /**
      * 401 UNAUTHROZIED

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -24,6 +24,7 @@ public enum ErrorType {
     INVALID_KEY_RESULT_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
     INVALID_TASK_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
     INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 이전 값보다 큰 값이 입력되어야합니다."),
+    INVALID_RECORD_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 목표값보다 작은 값이 입력되어야합니다."),
 
     /**
      * 401 UNAUTHROZIED

--- a/src/main/java/org/moonshot/server/global/constants/JWTConstants.java
+++ b/src/main/java/org/moonshot/server/global/constants/JWTConstants.java
@@ -3,7 +3,7 @@ package org.moonshot.server.global.constants;
 public class JWTConstants {
 
     public static final String USER_ID = "userId";
-    public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L * 20;  // 액세스 토큰 만료 시간: 20분으로 지정
-    public static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2;  // 리프레시 토큰 만료 시간: 2주로 지정
+    public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2;
+    public static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2; 
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #50 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- TokenResponse에 "Bearer" 추가하여 Response 수정하였습니다!
<img width="998" alt="스크린샷 2024-01-10 오후 10 11 16" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/d804ece8-06a9-4827-ad51-4c6ef8d270de">

- 엑세스토큰 만료 시간을 2주로 변경하였습니다. 앱잼 이후 다시 변경하겠습니다!

- Log 생성 시 진척정도를  목표값보다 큰 값을 입력했을 경우 Exception 추가하였습니다!
<img width="462" alt="스크린샷 2024-01-10 오후 10 10 47" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/7efb5f44-a390-471e-a755-8c88df4ad234">

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- 없습니다!
