### PR TITLE
[Fix] KeyResult 엔티티 변경에 따른 LogService, KeyResultService 변경

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -2,6 +2,7 @@ package org.moonshot.server.domain.keyresult.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestDto;
@@ -13,6 +14,8 @@ import org.moonshot.server.domain.keyresult.exception.KeyResultNotFoundException
 import org.moonshot.server.domain.keyresult.exception.KeyResultNumberExceededException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
+import org.moonshot.server.domain.log.exception.InvalidLogValueException;
+import org.moonshot.server.domain.log.exception.LogNotFoundException;
 import org.moonshot.server.domain.log.model.Log;
 import org.moonshot.server.domain.log.model.LogState;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
@@ -135,11 +138,15 @@ public class KeyResultService implements IndexService {
             LocalDateTime newExpireAt = (request.expireAt() != null) ? request.expireAt() : keyResult.getPeriod().getExpireAt();
             keyResult.modifyPeriod(Period.of(newStartAt, newExpireAt));
         }
-        if (request.target() != null) {
-            if (request.logContent() !=  null) {
-                logService.createUpdateLog(request, keyResult.getId());
+        if (request.target() != null && request.logContent() !=  null) {
+            Log updateLog = logService.createUpdateLog(request, keyResult.getId());
+            if (request.target().equals(updateLog.getKeyResult().getTarget())) {
+                throw new InvalidLogValueException();
             }
+            Log prevLog = logRepository.findLatestLogByKeyResultId(LogState.RECORD, request.keyResultId())
+                    .orElseThrow(LogNotFoundException::new);
             keyResult.modifyTarget(request.target());
+            keyResult.modifyProgress(logService.calculateProgressBar(prevLog, keyResult));
         }
         if (request.state() != null) {
             keyResult.modifyState(request.state());

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -185,8 +185,8 @@ public class KeyResultService implements IndexService {
                 logService.getLogResponseDto(logList, keyResult));
     }
 
-    public int calculateProgressBar(Log log, KeyResult keyResult) {
-        return (log != null) ? (int) (Math.round(log.getCurrNum() / (double) keyResult.getTarget() * 100)) : 0;
+    public short calculateProgressBar(Log log, KeyResult keyResult) {
+        return (log != null) ? (short) (Math.round(log.getCurrNum() / (double) keyResult.getTarget() * 100)) : 0;
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -178,15 +178,11 @@ public class KeyResultService implements IndexService {
             }
         }
         return KRDetailResponseDto.of(keyResult.getTitle(),
-                calculateProgressBar(target, keyResult),
+                logService.calculateProgressBar(target, keyResult),
                 keyResult.getState().getValue(),
                 keyResult.getPeriod().getStartAt(),
                 keyResult.getPeriod().getExpireAt(),
                 logService.getLogResponseDto(logList, keyResult));
-    }
-
-    public short calculateProgressBar(Log log, KeyResult keyResult) {
-        return (log != null) ? (short) (Math.round(log.getCurrNum() / (double) keyResult.getTarget() * 100)) : 0;
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/log/exception/InvalidLogValueException.java
+++ b/src/main/java/org/moonshot/server/domain/log/exception/InvalidLogValueException.java
@@ -5,5 +5,7 @@ import org.moonshot.server.global.common.response.ErrorType;
 
 public class InvalidLogValueException extends MoonshotException {
 
-    public InvalidLogValueException() { super(ErrorType.INVALID_LOG_VALUE); }
+    public InvalidLogValueException() {
+        super(ErrorType.INVALID_LOG_VALUE);
+    }
 }

--- a/src/main/java/org/moonshot/server/domain/log/exception/InvalidRecordException.java
+++ b/src/main/java/org/moonshot/server/domain/log/exception/InvalidRecordException.java
@@ -5,6 +5,8 @@ import org.moonshot.server.global.common.response.ErrorType;
 
 public class InvalidRecordException extends MoonshotException {
 
-    public InvalidRecordException() { super(ErrorType.INVALID_RECORD_VALUE); }
+    public InvalidRecordException() {
+        super(ErrorType.INVALID_RECORD_VALUE);
+    }
 
 }

--- a/src/main/java/org/moonshot/server/domain/log/exception/LogNotFoundException.java
+++ b/src/main/java/org/moonshot/server/domain/log/exception/LogNotFoundException.java
@@ -1,0 +1,12 @@
+package org.moonshot.server.domain.log.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class LogNotFoundException extends MoonshotException {
+
+    public LogNotFoundException() {
+        super(ErrorType.NOT_FOUND_LOG_ERROR);
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/log/service/LogService.java
+++ b/src/main/java/org/moonshot/server/domain/log/service/LogService.java
@@ -48,7 +48,7 @@ public class LogService {
         long prevNum = -1;
         if (!prevLog.isEmpty()) {
             prevNum = prevLog.get().getCurrNum();
-            if(request.logNum() < prevNum) {
+            if(request.logNum() == prevNum) {
                 throw new InvalidLogValueException();
             }
         }
@@ -64,10 +64,10 @@ public class LogService {
     }
 
     @Transactional
-    public void createUpdateLog(KeyResultModifyRequestDto request, Long keyResultId) {
+    public Log createUpdateLog(KeyResultModifyRequestDto request, Long keyResultId) {
         KeyResult keyResult = keyResultRepository.findById(keyResultId)
                 .orElseThrow(KeyResultNotFoundException::new);
-        Log log = logRepository.save(Log.builder()
+        return logRepository.save(Log.builder()
                 .date(LocalDateTime.now())
                 .state(LogState.UPDATE)
                 .currNum(request.target())
@@ -75,7 +75,6 @@ public class LogService {
                 .content(request.logContent())
                 .keyResult(keyResult)
                 .build());
-        keyResult.modifyProgress(calculateProgressBar(log, keyResult));
     }
 
     @Transactional

--- a/src/main/java/org/moonshot/server/domain/log/service/LogService.java
+++ b/src/main/java/org/moonshot/server/domain/log/service/LogService.java
@@ -7,6 +7,7 @@ import org.moonshot.server.domain.keyresult.dto.request.KeyResultModifyRequestDt
 import org.moonshot.server.domain.keyresult.exception.KeyResultNotFoundException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
 import org.moonshot.server.domain.keyresult.repository.KeyResultRepository;
+import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.log.dto.request.LogCreateRequestDto;
 import org.moonshot.server.domain.log.dto.response.LogResponseDto;
 import org.moonshot.server.domain.log.exception.InvalidLogValueException;
@@ -16,6 +17,8 @@ import org.moonshot.server.domain.log.model.LogState;
 import org.moonshot.server.domain.log.repository.LogRepository;
 import org.moonshot.server.domain.user.repository.UserRepository;
 import org.moonshot.server.global.auth.exception.AccessDeniedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +31,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LogService {
 
-    private final UserRepository userRepository;
     private final KeyResultRepository keyResultRepository;
     private final LogRepository logRepository;
 
@@ -50,7 +52,7 @@ public class LogService {
                 throw new InvalidLogValueException();
             }
         }
-        logRepository.save(Log.builder()
+        Log log = logRepository.save(Log.builder()
                 .date(LocalDateTime.now())
                 .state(LogState.RECORD)
                 .currNum(request.logNum())
@@ -58,14 +60,14 @@ public class LogService {
                 .content(request.logContent())
                 .keyResult(keyResult)
                 .build());
+        keyResult.modifyProgress(calculateProgressBar(log, keyResult));
     }
 
     @Transactional
     public void createUpdateLog(KeyResultModifyRequestDto request, Long keyResultId) {
         KeyResult keyResult = keyResultRepository.findById(keyResultId)
                 .orElseThrow(KeyResultNotFoundException::new);
-
-        logRepository.save(Log.builder()
+        Log log = logRepository.save(Log.builder()
                 .date(LocalDateTime.now())
                 .state(LogState.UPDATE)
                 .currNum(request.target())
@@ -73,6 +75,7 @@ public class LogService {
                 .content(request.logContent())
                 .keyResult(keyResult)
                 .build());
+        keyResult.modifyProgress(calculateProgressBar(log, keyResult));
     }
 
     @Transactional
@@ -122,6 +125,10 @@ public class LogService {
             return (prevNum == -1 ? "0" : prevNum) + keyResult.getMetric()
                     + " → " + currNum + keyResult.getMetric();
         }
+    }
+
+    public short calculateProgressBar(Log log, KeyResult keyResult) {
+        return (log != null) ? (short) (Math.round(log.getCurrNum() / (double) keyResult.getTarget() * 100)) : 0;
     }
 
 }

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -23,7 +23,7 @@ public enum ErrorType {
     ACTIVE_TASK_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Task 개수를 초과하였습니다."),
     INVALID_KEY_RESULT_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
     INVALID_TASK_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
-    INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 이전 값보다 큰 값이 입력되어야합니다."),
+    INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "Log 입력값은 이전 값과 동일할 수 없습니다."),
     INVALID_EXPIRE_AT(HttpStatus.BAD_REQUEST, "Objective 종료 기간은 오늘보다 이전 날짜일 수 없습니다."),
     INVALID_RECORD_VALUE(HttpStatus.BAD_REQUEST, "진척 정도는 목표값보다 작은 값이 입력되어야 합니다."),
 
@@ -47,6 +47,7 @@ public enum ErrorType {
     NOT_FOUND_OBJECTIVE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Objective입니다."),
     NOT_FOUND_KEY_RESULT_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 KeyResult입니다."),
     NOT_FOUND_TASK_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Task입니다."),
+    NOT_FOUND_LOG_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 Log입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #58 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 엔티티 변경에 따른 keyResultService, LogService 수정했습니다.

- 기존 progress 계산을 keyResultService에서 진행하였는데 logService로 이동하였습니다.

- 기획 측 요구에 따라 이전값보다 큰 값을 입력 받았던 진척상황을 같은 상황일때만 예외가 발생하도록 수정하였습니다. (KR 수정 Log도 동일)
<img width="1076" alt="스크린샷 2024-01-11 오전 6 03 22" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/74ee11e8-d088-480f-8d44-0bcd404caf1d">

- Recordlog, UpdateLog가 생성되면 keyResult progress값 변경되도록 구현하였습니다.


### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
없습니다!
