### PR TITLE
[Add] #62 : 대시보드에서 조회하는 Objective의 Tree를 선택할 수 있는 기능 추가

### DIFF
--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -1,5 +1,6 @@
 package org.moonshot.server.domain.objective.controller;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,8 +49,8 @@ public class ObjectiveController {
     }
 
     @GetMapping
-    public ApiResponse<DashboardResponseDto> getObjectiveInDashboard(Principal principal) {
-        DashboardResponseDto response = objectiveService.getObjectiveInDashboard(JwtTokenProvider.getUserIdFromPrincipal(principal));
+    public ApiResponse<DashboardResponseDto> getObjectiveInDashboard(Principal principal, @Nullable @RequestParam("objectiveId") Long objectiveId) {
+        DashboardResponseDto response = objectiveService.getObjectiveInDashboard(JwtTokenProvider.getUserIdFromPrincipal(principal), objectiveId);
         return ApiResponse.success(SuccessType.GET_OKR_LIST_SUCCESS, response);
     }
 

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -78,9 +78,10 @@ public class ObjectiveService {
         }
     }
 
-    public DashboardResponseDto getObjectiveInDashboard(Long userId) {
+    public DashboardResponseDto getObjectiveInDashboard(Long userId, Long objectiveId) {
         List<Objective> objList = objectiveRepository.findAllByUserId(userId);
-        Objective objective = objectiveRepository.findByIdWithKeyResultsAndTasks(objList.get(0).getId())
+        Long treeId = objectiveId == null ? objList.get(0).getId() : objectiveId;
+        Objective objective = objectiveRepository.findByIdWithKeyResultsAndTasks(treeId)
                 .orElseThrow(ObjectiveNotFoundException::new);
         if (!objective.getUser().getId().equals(userId)) {
             throw new AccessDeniedException();


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #62 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 메인 대시보드에서 조회하는 Objective를 선택할 수 있는 기능 추가
- objectiveId를 nullable하게 둔 이유는 objectiveId가 없을 때는 왼쪽 리스트의 가장 최근 objective를 조회하게 됨.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
