### PR TITLE
[Feat] #61 - 히스토리 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ data.sql
 
 # End of https://www.gitignore.io/api/java,macos,gradle,intellij
 
+src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,12 @@ dependencies {
 
 	// Mybatis
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.0'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/src/main/java/org/moonshot/server/domain/keyresult/model/KeyResult.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/model/KeyResult.java
@@ -55,7 +55,7 @@ public class KeyResult {
     private Objective objective;
 
     @JsonIgnore
-    @BatchSize(size = 10)
+    @BatchSize(size = 200)
     @OneToMany(mappedBy = "keyResult", fetch = FetchType.LAZY)
     List<Task> taskList = new ArrayList<>();
 

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.moonshot.server.domain.objective.dto.request.ModifyObjectiveRequestDto;
 import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
+import org.moonshot.server.domain.objective.dto.request.ObjectiveHistoryRequestDto;
 import org.moonshot.server.domain.objective.dto.response.DashboardResponseDto;
+import org.moonshot.server.domain.objective.dto.response.HistoryResponseDto;
 import org.moonshot.server.domain.objective.service.ObjectiveService;
 import org.moonshot.server.global.auth.jwt.JwtTokenProvider;
 import org.moonshot.server.global.common.response.ApiResponse;
@@ -52,6 +54,13 @@ public class ObjectiveController {
     public ApiResponse<DashboardResponseDto> getObjectiveInDashboard(Principal principal, @Nullable @RequestParam("objectiveId") Long objectiveId) {
         DashboardResponseDto response = objectiveService.getObjectiveInDashboard(JwtTokenProvider.getUserIdFromPrincipal(principal), objectiveId);
         return ApiResponse.success(SuccessType.GET_OKR_LIST_SUCCESS, response);
+    }
+
+    @GetMapping("/history")
+    public ApiResponse<HistoryResponseDto> getObjectiveHistory(Principal principal, @RequestBody ObjectiveHistoryRequestDto request) {
+        HistoryResponseDto response = objectiveService.getObjectiveHistory(
+                JwtTokenProvider.getUserIdFromPrincipal(principal), request);
+        return ApiResponse.success(SuccessType.OK, response);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/ObjectiveHistoryRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/ObjectiveHistoryRequestDto.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.objective.dto.request;
+
+import org.moonshot.server.domain.objective.model.Category;
+
+public record ObjectiveHistoryRequestDto(
+        Integer year,
+        Category category,
+        String criteria
+) {
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryKeyResultDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryKeyResultDto.java
@@ -1,0 +1,22 @@
+package org.moonshot.server.domain.objective.dto.response;
+
+import java.util.List;
+import org.moonshot.server.domain.keyresult.model.KeyResult;
+
+public record HistoryKeyResultDto(
+        Long krId,
+        String krTitle,
+        int krProgress,
+        Integer krIdx,
+        List<HistoryTaskDto> taskList
+) {
+    public static HistoryKeyResultDto of(KeyResult keyResult) {
+        return new HistoryKeyResultDto(
+                keyResult.getId(),
+                keyResult.getTitle(),
+                keyResult.getProgress(),
+                keyResult.getIdx(),
+                keyResult.getTaskList().stream().map(HistoryTaskDto::of).toList()
+        );
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryObjectiveListDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryObjectiveListDto.java
@@ -1,0 +1,30 @@
+package org.moonshot.server.domain.objective.dto.response;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.moonshot.server.domain.objective.model.Objective;
+
+public record HistoryObjectiveListDto(
+        Long objId,
+        String title,
+        String objCategory,
+        int progress,
+        String objPeriod,
+        Short objIdx,
+        List<HistoryKeyResultDto> krList
+) {
+    public static HistoryObjectiveListDto of(Objective objective) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd");
+        String objPeriod = objective.getPeriod().getStartAt().format(formatter) + " - " + objective.getPeriod().getExpireAt()
+                .format(formatter);
+        return new HistoryObjectiveListDto(
+                objective.getId(),
+                objective.getTitle(),
+                objective.getCategory().getValue(),
+                objective.getProgress(),
+                objPeriod,
+                objective.getIdx(),
+                objective.getKeyResultList().stream().map(HistoryKeyResultDto::of).toList()
+        );
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryResponseDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryResponseDto.java
@@ -1,0 +1,21 @@
+package org.moonshot.server.domain.objective.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.moonshot.server.domain.objective.model.Objective;
+
+public record HistoryResponseDto(
+        List<ObjectiveGroupByYearDto> groups,
+        List<Integer> years,
+        List<String> categories
+) {
+    public static HistoryResponseDto of(Map<Integer, List<Objective>> groups, List<String> categories) {
+        return new HistoryResponseDto(
+                groups.entrySet().stream().map(entry -> ObjectiveGroupByYearDto.of(entry.getKey(), entry.getValue())).toList(),
+                groups.keySet().stream().distinct().toList(),
+                categories.stream().distinct().toList()
+        );
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryTaskDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryTaskDto.java
@@ -1,0 +1,17 @@
+package org.moonshot.server.domain.objective.dto.response;
+
+import org.moonshot.server.domain.task.model.Task;
+
+public record HistoryTaskDto(
+        Long taskId,
+        String taskTitle,
+        Integer taskIdx
+) {
+    public static HistoryTaskDto of(Task task) {
+        return new HistoryTaskDto(
+                task.getId(),
+                task.getTitle(),
+                task.getIdx()
+        );
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/ObjectiveGroupByYearDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/ObjectiveGroupByYearDto.java
@@ -1,0 +1,19 @@
+package org.moonshot.server.domain.objective.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.moonshot.server.domain.objective.model.Objective;
+
+public record ObjectiveGroupByYearDto(
+        int year,
+        int count,
+        List<HistoryObjectiveListDto> objList
+) {
+    public static ObjectiveGroupByYearDto of(Integer year, List<Objective> objList) {
+        return new ObjectiveGroupByYearDto(
+                year,
+                objList.size(),
+                objList.stream().map(HistoryObjectiveListDto::of).toList());
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
@@ -60,7 +60,7 @@ public class Objective {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-    @BatchSize(size = 10)
+    @BatchSize(size = 200)
     @OneToMany(mappedBy = "objective", fetch = FetchType.LAZY)
     List<KeyResult> keyResultList = new ArrayList<>();
 

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepository.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepository.java
@@ -1,0 +1,11 @@
+package org.moonshot.server.domain.objective.repository;
+
+import java.util.List;
+import org.moonshot.server.domain.objective.dto.request.ObjectiveHistoryRequestDto;
+import org.moonshot.server.domain.objective.dto.response.HistoryResponseDto;
+
+public interface ObjectiveCustomRepository {
+
+    HistoryResponseDto findObjectives(ObjectiveHistoryRequestDto request);
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
@@ -1,0 +1,81 @@
+package org.moonshot.server.domain.objective.repository;
+
+import static org.moonshot.server.domain.keyresult.model.QKeyResult.*;
+import static org.moonshot.server.domain.objective.model.QObjective.*;
+import static org.moonshot.server.domain.task.model.QTask.*;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.moonshot.server.domain.keyresult.model.QKeyResult;
+import org.moonshot.server.domain.objective.dto.request.ObjectiveHistoryRequestDto;
+import org.moonshot.server.domain.objective.dto.response.DashboardResponseDto;
+import org.moonshot.server.domain.objective.dto.response.HistoryResponseDto;
+import org.moonshot.server.domain.objective.model.Category;
+import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.objective.model.QObjective;
+import org.moonshot.server.domain.task.model.QTask;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ObjectiveCustomRepositoryImpl implements ObjectiveCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public HistoryResponseDto findObjectives(ObjectiveHistoryRequestDto request) {
+        List<Objective> objectives = queryFactory.selectFrom(objective).distinct()
+                .join(objective.keyResultList, keyResult).fetchJoin()
+                .join(keyResult.taskList, task)
+                .where(yearEq(request.year()), categoryEq(request.category()))
+                .orderBy(order(request.criteria()), keyResult.idx.asc())
+                .fetch();
+
+        Map<Integer, List<Objective>> groups = objectives.stream()
+                .collect(Collectors.groupingBy(objective -> objective.getPeriod().getStartAt().getYear()));
+
+        List<String> categories = objectives.stream().map(objective -> objective.getCategory().getValue()).toList();
+
+        return HistoryResponseDto.of(groups, categories);
+    }
+
+    private BooleanExpression yearEq(Integer year) {
+        return year != null ? objective.period.expireAt.year().eq(year) : null;
+    }
+
+    private BooleanExpression categoryEq(Category category) {
+        return category != null ? objective.category.eq(category) : null;
+    }
+
+    private OrderSpecifier<?> order(String orderBy) {
+        OrderSpecifier<?> orderSpecifier;
+
+        if (orderBy == null) {
+            return objective.period.startAt.asc();
+        }
+
+        switch (orderBy) {
+            case "LATEST":
+                orderSpecifier = objective.period.startAt.asc();
+                break;
+            case "OLDEST":
+                orderSpecifier = objective.period.startAt.desc();
+                break;
+            case "ACCOMPLISH":
+                orderSpecifier = objective.progress.desc();
+            default:
+                orderSpecifier = objective.period.startAt.asc();
+                break;
+        }
+        return orderSpecifier;
+    }
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -91,7 +91,6 @@ public class ObjectiveService {
             throw new AccessDeniedException();
         }
         return DashboardResponseDto.of(objective, objList);
-//        return objectiveCustomRepository.findObjectives();
     }
 
     public HistoryResponseDto getObjectiveHistory(Long userId, ObjectiveHistoryRequestDto request) {

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -6,11 +6,15 @@ import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.objective.dto.request.ModifyObjectiveRequestDto;
 import org.moonshot.server.domain.objective.dto.request.OKRCreateRequestDto;
+import org.moonshot.server.domain.objective.dto.request.ObjectiveHistoryRequestDto;
 import org.moonshot.server.domain.objective.dto.response.DashboardResponseDto;
+import org.moonshot.server.domain.objective.dto.response.HistoryResponseDto;
 import org.moonshot.server.domain.objective.exception.InvalidExpiredAtException;
 import org.moonshot.server.domain.objective.exception.ObjectiveNotFoundException;
 import org.moonshot.server.domain.objective.exception.ObjectiveNumberExceededException;
+import org.moonshot.server.domain.objective.model.Category;
 import org.moonshot.server.domain.objective.model.Objective;
+import org.moonshot.server.domain.objective.repository.ObjectiveCustomRepository;
 import org.moonshot.server.domain.objective.repository.ObjectiveRepository;
 import org.moonshot.server.domain.user.exception.UserNotFoundException;
 import org.moonshot.server.domain.user.model.User;
@@ -32,6 +36,7 @@ public class ObjectiveService {
     private final KeyResultService keyResultService;
     private final UserRepository userRepository;
     private final ObjectiveRepository objectiveRepository;
+    private final ObjectiveCustomRepository objectiveCustomRepository;
 
     @Transactional
     public void createObjective(Long userId, OKRCreateRequestDto request) {
@@ -86,6 +91,11 @@ public class ObjectiveService {
             throw new AccessDeniedException();
         }
         return DashboardResponseDto.of(objective, objList);
+//        return objectiveCustomRepository.findObjectives();
+    }
+
+    public HistoryResponseDto getObjectiveHistory(Long userId, ObjectiveHistoryRequestDto request) {
+        return objectiveCustomRepository.findObjectives(request);
     }
 
 }

--- a/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/SuccessType.java
@@ -15,6 +15,7 @@ public enum SuccessType {
     OK(HttpStatus.OK, "성공"),
     GET_PRESIGNED_URL_SUCCESS(HttpStatus.OK, "Presigned Url 조회에 성공하였습니다."),
     GET_OKR_LIST_SUCCESS(HttpStatus.OK, "O-KR 목록 조회에 성공하였습니다."),
+    GET_HISTORY_SUCCESS(HttpStatus.OK, "히스토리 조회에 성공하였습니다."),
     POST_LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
     POST_REISSUE_SUCCESS(HttpStatus.OK, "엑세스 토큰 재발급에 성공하였습니다."),
     POST_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공하였습니다."),

--- a/src/main/java/org/moonshot/server/global/config/QuerydslConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package org.moonshot.server.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    JPAQueryFactory queryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
+}


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #61 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- QueryDSL gradle 추가
- 히스토리 API 형식에 맞춘 DTO record 구현
- (페이징 적용 기준) 히스토리 조회 시 KeyResult 개수가 200개 미만으로 간주되어 BatchSize로 200으로 설정하였음
- 히스토리 조회 시 동적 쿼리 적용 (추후 Mybatis로 리팩토링 예정.. 지식이 부족하여 공부 후에 적용할 것임)

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
