### PR TITLE
[Fix] #91 - permitAll 대상 API token validation 회피 로직 추가

### DIFF
--- a/src/main/java/org/moonshot/server/global/auth/filter/MoonshotExceptionHandler.java
+++ b/src/main/java/org/moonshot/server/global/auth/filter/MoonshotExceptionHandler.java
@@ -18,13 +18,13 @@ public class MoonshotExceptionHandler implements AccessDeniedHandler, Authentica
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
-
+        log.error("Authentication Exception Occurs!");
     }
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
-
+        log.error("Forbidden Exception Occurs!");
     }
 
 }

--- a/src/main/java/org/moonshot/server/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/moonshot/server/global/auth/security/JwtAuthenticationFilter.java
@@ -37,9 +37,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
-        if (request.getAttribute("exception") != null) {
-            throw new MoonshotException((ErrorType) request.getAttribute("exception"));
-        }
         final String token = getJwtFromRequest(request);
         if (jwtTokenProvider.validateAccessToken(token) == JwtValidationType.VALID_JWT) {
             Long userId = jwtTokenProvider.getUserFromJwt(token);

--- a/src/main/java/org/moonshot/server/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/moonshot/server/global/auth/security/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.moonshot.server.global.auth.jwt.JwtTokenProvider;
 import org.moonshot.server.global.auth.jwt.JwtValidationType;
 import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
+import org.moonshot.server.global.constants.WhiteListConstants;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws IOException, ServletException, IOException {
+        if (WhiteListConstants.WHITELIST.contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         if (request.getAttribute("exception") != null) {
             throw new MoonshotException((ErrorType) request.getAttribute("exception"));
         }

--- a/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/moonshot/server/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.moonshot.server.global.auth.filter.MoonshotExceptionHandler;
 import org.moonshot.server.global.auth.security.JwtAuthenticationFilter;
 import org.moonshot.server.global.auth.security.JwtExceptionFilter;
+import org.moonshot.server.global.constants.WhiteListConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,18 +22,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-    private static final String[] WHITELIST = {
-            "/login/**",
-            "/",
-            "/actuator/health",
-            "/v1/user/**",
-            "/v1/image",
-            "/error",
-            "/swagger-ui/**",
-            "/swagger-resources/**",
-            "/api-docs/**"
-    };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final MoonshotExceptionHandler moonshotExceptionHandler;
@@ -57,7 +46,7 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.accessDeniedHandler(moonshotExceptionHandler))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry.requestMatchers(WHITELIST).permitAll())
+                        authorizationManagerRequestMatcherRegistry.requestMatchers(WhiteListConstants.WHITELIST.toArray(new String[0])).permitAll())
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->

--- a/src/main/java/org/moonshot/server/global/constants/WhiteListConstants.java
+++ b/src/main/java/org/moonshot/server/global/constants/WhiteListConstants.java
@@ -1,0 +1,19 @@
+package org.moonshot.server.global.constants;
+
+import java.util.List;
+
+public class WhiteListConstants {
+
+    public static final List<String> WHITELIST = List.of(
+            "/login/**",
+            "/",
+            "/actuator/health",
+            "/v1/user/**",
+            "/v1/image",
+            "/error",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/api-docs/**"
+    );
+
+}


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #91 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- permitAll 대상 FilterChain에서 Token이 없어서 생기는 에러가 발생함. 그래서 이 에러를 발생시키지 않기 위해 토큰이 있는지 확인하는 로직 전에 다음 필터로 넘겨버리도록 하였음.
- WhiteList를 Constants로 분리하여 관리하도록 하였음.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
