### PR TITLE
[Refactor] #107 - 히스토리 API 동적 쿼리 레포지토리 역할 줄이고 Service Layer에서 비즈니스 로직 처리로 변경

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyresult/controller/KeyResultApi.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/controller/KeyResultApi.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface KeyResultApi {
 
     @ApiResponses(value =  {
-            @ApiResponse(responseCode = "201", description = "KeyResult 생성을 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "201", description = "KeyResult 생성을 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "허용된 Key Result 개수를 초과하였습니다\t\n정상적이지 않은 KeyResult 위치입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
@@ -30,7 +30,7 @@ public interface KeyResultApi {
     public ResponseEntity<MoonshotResponse<?>> createKeyResult(Principal principal, @RequestBody @Valid KeyResultCreateRequestDto request);
 
     @ApiResponses(value =  {
-            @ApiResponse(responseCode = "204", description = "KeyResult 삭제를 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "204", description = "KeyResult 삭제를 성공하였습니다"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 KeyResult입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
@@ -39,7 +39,7 @@ public interface KeyResultApi {
     public ResponseEntity<?> deleteKeyResult(Principal principal, @PathVariable("keyResultId") Long keyResultId);
 
     @ApiResponses(value =  {
-            @ApiResponse(responseCode = "200", description = "KeyResult 수정 후 목표를 달성하였습니다\t\nKeyResult 수정을 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "200", description = "KeyResult 수정 후 목표를 달성하였습니다\t\nKeyResult 수정을 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "Log 입력값은 이전 값과 동일할 수 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
@@ -49,7 +49,7 @@ public interface KeyResultApi {
     public ResponseEntity<MoonshotResponse<?>> modifyKeyResult(Principal principal, @RequestBody @Valid KeyResultModifyRequestDto request);
 
     @ApiResponses(value =  {
-            @ApiResponse(responseCode = "201", description = "O-KR을 생성을 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "201", description = "O-KR을 생성을 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "허용된 Objective 개수를 초과하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),

--- a/src/main/java/org/moonshot/server/domain/log/controller/LogApi.java
+++ b/src/main/java/org/moonshot/server/domain/log/controller/LogApi.java
@@ -20,8 +20,7 @@ import java.security.Principal;
 public interface LogApi {
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Log 생성을 성공하였습니다.",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "201", description = "Log 생성을 성공하였습니다."),
             @ApiResponse(responseCode = "400", description = "Log 입력값은 이전 값과 동일할 수 없습니다.",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다.",

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveApi.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveApi.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 interface ObjectiveApi {
 
     @ApiResponses(value =  {
-            @ApiResponse(responseCode = "201", description = "O-KR을 생성을 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "201", description = "O-KR을 생성을 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "허용된 Objective 개수를 초과하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
@@ -36,7 +36,7 @@ interface ObjectiveApi {
                                                         @RequestBody @Valid OKRCreateRequestDto request);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "O-KR 트리 삭제를 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "204", description = "O-KR 트리 삭제를 성공하였습니다"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 Objective입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
@@ -46,18 +46,18 @@ interface ObjectiveApi {
                                       @PathVariable("objectiveId") Long objectiveId);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "Objective 수정에 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "204", description = "Objective 수정에 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "Objective 종료 기간은 오늘보다 이전 날짜일 수 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 Objective입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
     })
     @Operation(summary = "Objective 데이터 수정")
-    ResponseEntity<MoonshotResponse<?>> modifyObjective(@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Access Token", required = true, schema = @Schema(type = "string")) Principal principal,
+    ResponseEntity<?> modifyObjective(@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Access Token", required = true, schema = @Schema(type = "string")) Principal principal,
                                                         @RequestBody ModifyObjectiveRequestDto request);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "O-KR 목록 조회에 성공하였습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "200", description = "O-KR 목록 조회에 성공하였습니다"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 Objective입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
@@ -67,7 +67,7 @@ interface ObjectiveApi {
                                                                                    @Nullable @RequestParam("objectiveId") Long objectiveId);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "히스토리 조회에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "200", description = "히스토리 조회에 성공하였습니다."),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
             @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
     })

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -47,7 +47,7 @@ public class ObjectiveController implements ObjectiveApi {
     }
 
     @PatchMapping
-    public ResponseEntity<MoonshotResponse<?>> modifyObjective(Principal principal, @RequestBody ModifyObjectiveRequestDto request) {
+    public ResponseEntity<?> modifyObjective(Principal principal, @RequestBody ModifyObjectiveRequestDto request) {
         objectiveService.modifyObjective(JwtTokenProvider.getUserIdFromPrincipal(principal), request);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/ObjectiveController.java
@@ -60,8 +60,7 @@ public class ObjectiveController implements ObjectiveApi {
 
     @GetMapping("/history")
     public ResponseEntity<MoonshotResponse<HistoryResponseDto>> getObjectiveHistory(Principal principal, @RequestBody ObjectiveHistoryRequestDto request) {
-        HistoryResponseDto response = objectiveService.getObjectiveHistory(
-                JwtTokenProvider.getUserIdFromPrincipal(principal), request);
+        HistoryResponseDto response = objectiveService.getObjectiveHistory(JwtTokenProvider.getUserIdFromPrincipal(principal), request);
         return ResponseEntity.ok(MoonshotResponse.success(SuccessType.OK, response));
     }
 

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepository.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepository.java
@@ -3,9 +3,10 @@ package org.moonshot.server.domain.objective.repository;
 import java.util.List;
 import org.moonshot.server.domain.objective.dto.request.ObjectiveHistoryRequestDto;
 import org.moonshot.server.domain.objective.dto.response.HistoryResponseDto;
+import org.moonshot.server.domain.objective.model.Objective;
 
 public interface ObjectiveCustomRepository {
 
-    HistoryResponseDto findObjectives(ObjectiveHistoryRequestDto request);
+    List<Objective> findObjectives(Long userId, ObjectiveHistoryRequestDto request);
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
@@ -35,7 +35,7 @@ public class ObjectiveCustomRepositoryImpl implements ObjectiveCustomRepository 
                 .join(objective.keyResultList, keyResult).fetchJoin()
                 .join(keyResult.taskList, task)
                 .where(objective.isClosed.eq(true), userEq(userId), yearEq(request.year()), categoryEq(request.category()))
-                .orderBy(order(request.criteria()), keyResult.idx.asc())
+                .orderBy(order(request.criteria()), keyResult.idx.asc(), task.idx.asc())
                 .fetch();
     }
 

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveCustomRepositoryImpl.java
@@ -30,24 +30,21 @@ public class ObjectiveCustomRepositoryImpl implements ObjectiveCustomRepository 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public HistoryResponseDto findObjectives(ObjectiveHistoryRequestDto request) {
-        List<Objective> objectives = queryFactory.selectFrom(objective).distinct()
+    public List<Objective> findObjectives(Long userId, ObjectiveHistoryRequestDto request) {
+        return queryFactory.selectFrom(objective).distinct()
                 .join(objective.keyResultList, keyResult).fetchJoin()
                 .join(keyResult.taskList, task)
-                .where(yearEq(request.year()), categoryEq(request.category()))
+                .where(objective.isClosed.eq(true), userEq(userId), yearEq(request.year()), categoryEq(request.category()))
                 .orderBy(order(request.criteria()), keyResult.idx.asc())
                 .fetch();
+    }
 
-        Map<Integer, List<Objective>> groups = objectives.stream()
-                .collect(Collectors.groupingBy(objective -> objective.getPeriod().getStartAt().getYear()));
-
-        List<String> categories = objectives.stream().map(objective -> objective.getCategory().getValue()).toList();
-
-        return HistoryResponseDto.of(groups, categories);
+    private BooleanExpression userEq(Long userId) {
+        return userId != null ? objective.user.id.eq(userId) : null;
     }
 
     private BooleanExpression yearEq(Integer year) {
-        return year != null ? objective.period.expireAt.year().eq(year) : null;
+        return year != null ? objective.period.startAt.year().eq(year) : null;
     }
 
     private BooleanExpression categoryEq(Category category) {

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -2,6 +2,8 @@ package org.moonshot.server.domain.objective.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.objective.dto.request.ModifyObjectiveRequestDto;
@@ -91,7 +93,12 @@ public class ObjectiveService {
     }
 
     public HistoryResponseDto getObjectiveHistory(Long userId, ObjectiveHistoryRequestDto request) {
-        return objectiveRepository.findObjectives(request);
+        List<Objective> objectives = objectiveRepository.findObjectives(userId, request);
+        Map<Integer, List<Objective>> groups = objectives.stream()
+                .collect(Collectors.groupingBy(objective -> objective.getPeriod().getStartAt().getYear()));
+        List<String> categories = objectives.stream().map(objective -> objective.getCategory().getValue()).toList();
+
+        return HistoryResponseDto.of(groups, categories);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/task/controller/TaskApi.java
+++ b/src/main/java/org/moonshot/server/domain/task/controller/TaskApi.java
@@ -20,8 +20,7 @@ import java.security.Principal;
 public interface TaskApi {
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Task 생성을 성공하였습니다",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "201", description = "Task 생성을 성공하였습니다"),
             @ApiResponse(responseCode = "400", description = "1.해당 자원에 접근 권한이 없습니다\t\n2.허용된 Task 개수를 초과하였습니다\t\n3.정상적이지 않은 KeyResult 위치입니다\t\n",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
     })

--- a/src/main/java/org/moonshot/server/domain/user/controller/UserApi.java
+++ b/src/main/java/org/moonshot/server/domain/user/controller/UserApi.java
@@ -28,35 +28,22 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @Tag(name = "User", description = "유저 관련 API")
 public interface UserApi {
 
-    @ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
-    @Operation(summary = "소셜 회원가입 및 로그인",
-    requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            content = @Content(
-                    mediaType = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                    schema = @Schema(
-                            allOf = { User.class },
-                            requiredProperties = { "socialPlatform", "code" }
-                    )
-            )
-    ))
+    @ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다.")
+    @Operation(summary = "소셜 회원가입 및 로그인")
     public ResponseEntity<MoonshotResponse<SocialLoginResponse>> login(@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인가 코드", required = true, schema = @Schema(type = "string")) @RequestHeader("Authorization") String authorization,
                                                                        @RequestBody SocialLoginRequest socialLoginRequest) throws IOException;
 
-    @ApiResponse(responseCode = "200", description = "엑세스 토큰 재발급에 성공하였습니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
+    @ApiResponse(responseCode = "200", description = "엑세스 토큰 재발급에 성공하였습니다.")
     @Operation(summary = "액세스 토큰 재발급")
     public ResponseEntity<MoonshotResponse<TokenResponse>> reissue(@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인가 코드", required = true, schema = @Schema(type = "string")) @RequestHeader("Authorization") String refreshToken);
 
 
-    @ApiResponse(responseCode = "200", description = "로그아웃에 성공하였습니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
+    @ApiResponse(responseCode = "200", description = "로그아웃에 성공하였습니다.")
     @Operation(summary = "로그아웃")
     public ResponseEntity<MoonshotResponse<?>> logout(Principal principal);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "로그아웃에 성공하였습니다.",
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "204", description = "로그아웃에 성공하였습니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
     })
@@ -64,8 +51,7 @@ public interface UserApi {
     public ResponseEntity<?> withdrawal(Principal principal);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "사용자 프로필 업데이트에 성공하였습니다.",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "204", description = "사용자 프로필 업데이트에 성공하였습니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
     })
@@ -75,16 +61,14 @@ public interface UserApi {
                                            @Valid @RequestBody UserInfoRequest userInfoRequest);
 
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 프로필 조회에 성공하였습니다.",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "200", description = "사용자 프로필 조회에 성공하였습니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 유저입니다.",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
     })
     @Operation(summary = "프로필 조회")
     public ResponseEntity<MoonshotResponse<UserInfoResponse>> getMyProfile(Principal principal);
 
-    @ApiResponse(responseCode = "200", description = "구글 로그인에 성공하였습니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
+    @ApiResponse(responseCode = "200", description = "구글 로그인에 성공하였습니다.")
     @Operation(summary = "구글 로그인")
     public String authTest(HttpServletRequest request, HttpServletResponse response);
 


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #107 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Swagger 성공 케이스 ApiResponse schema 제외하여 response body 제대로 나오도록 설정
- modifyObjective response type 변경
- History 조회 동적 쿼리 API repository 로직 service layer로 변경

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
