### PR TITLE
[Refactor] #110 - Index 수정 API Objective 추가 및 추가 예외 처리

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyresult/dto/response/KeyResultResponseDto.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/dto/response/KeyResultResponseDto.java
@@ -13,7 +13,7 @@ public record KeyResultResponseDto(
     public static List<KeyResultResponseDto> of(List<KeyResult> krList) {
         return krList.stream().map(kr -> new KeyResultResponseDto(
                 kr.getId(),
-                kr.getTitle(),
+                kr.getTitle() + ": " + kr.getTarget() + kr.getMetric(),
                 kr.getIdx(),
                 TaskResponseDto.of(kr.getTaskList())
         )).toList();

--- a/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidIndexException.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidIndexException.java
@@ -3,9 +3,9 @@ package org.moonshot.server.domain.keyresult.exception;
 import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
 
-public class KeyResultInvalidPositionException extends MoonshotException {
+public class KeyResultInvalidIndexException extends MoonshotException {
 
-    public KeyResultInvalidPositionException() {
+    public KeyResultInvalidIndexException() {
         super(ErrorType.INVALID_KEY_RESULT_INDEX);
     }
 

--- a/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidPositionException.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidPositionException.java
@@ -6,7 +6,7 @@ import org.moonshot.server.global.common.response.ErrorType;
 public class KeyResultInvalidPositionException extends MoonshotException {
 
     public KeyResultInvalidPositionException() {
-        super(ErrorType.INVALID_KEY_RESULT_ORDER);
+        super(ErrorType.INVALID_KEY_RESULT_INDEX);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/repository/KeyResultRepository.java
@@ -16,6 +16,8 @@ public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
     List<KeyResult> findAllByObjective(Objective objective);
     List<KeyResult> findAllByObjectiveOrderByIdx(Objective objective);
     List<KeyResult> findAllByObjectiveId(Long objectiveId);
+    @Query("select count(kr) from KeyResult kr join kr.objective obj where obj.id = :objectiveId")
+    Long countAllByObjectiveId(@Param("objectiveId") Long objectiveId);
     @Query("select kr from KeyResult kr join fetch kr.objective join fetch kr.objective.user where kr.id = :keyResultId")
     Optional<KeyResult> findKeyResultAndObjective(@Param("keyResultId") Long keyResultId);
     @Modifying(clearAutomatically = true)

--- a/src/main/java/org/moonshot/server/domain/objective/controller/IndexApi.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/IndexApi.java
@@ -1,0 +1,29 @@
+package org.moonshot.server.domain.objective.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
+import org.moonshot.server.global.common.response.MoonshotResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Index", description = "Index 수정 API")
+public interface IndexApi {
+
+    @ApiResponses(value =  {
+            @ApiResponse(responseCode = "204", description = "대상의 순서 수정을 성공하였습니다"),
+            @ApiResponse(responseCode = "400", description = "정상적이지 않은 Objective 위치입니다\t\n정상적이지 않은 KeyResult 위치입니다\t\n정상적이지 않은 Task 위치입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 Objective입니다\t\n존재하지 않는 KeyResult입니다\t\n존재하지 않는 Task입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
+    })
+    @Operation(summary = "Objective, KeyResult, Task Index 변경")
+    public ResponseEntity<MoonshotResponse<?>> modifyIdx(Principal principal, @RequestBody @Valid ModifyIndexRequestDto request);
+
+}

--- a/src/main/java/org/moonshot/server/domain/objective/controller/IndexController.java
+++ b/src/main/java/org/moonshot/server/domain/objective/controller/IndexController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/index")
-public class IndexController {
+public class IndexController implements IndexApi {
 
     private final IndexTargetProvider indexTargetProvider;
 
@@ -27,7 +27,7 @@ public class IndexController {
     public ResponseEntity<MoonshotResponse<?>> modifyIdx(Principal principal, @RequestBody @Valid ModifyIndexRequestDto request) {
         IndexService indexService = indexTargetProvider.getIndexService(request.target());
         indexService.modifyIdx(request, JwtTokenProvider.getUserIdFromPrincipal(principal));
-        return ResponseEntity.status(HttpStatus.OK).body(MoonshotResponse.success(SuccessType.PATCH_TARGET_INDEX_SUCCESS));
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/request/ModifyIndexRequestDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/request/ModifyIndexRequestDto.java
@@ -10,7 +10,6 @@ public record ModifyIndexRequestDto(
         @NotNull(message = "대상을 지정해주세요.")
         IndexTarget target,
         @NotNull(message = "대상의 이동할 위치 값을 입력하세요.")
-        @Range(min = 0, max = 2, message = "순서는 0부터 2까지로 설정할 수 있습니다.")
         Integer idx
 ) {
 }

--- a/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryObjectiveListDto.java
+++ b/src/main/java/org/moonshot/server/domain/objective/dto/response/HistoryObjectiveListDto.java
@@ -10,7 +10,7 @@ public record HistoryObjectiveListDto(
         String objCategory,
         int progress,
         String objPeriod,
-        Short objIdx,
+        int objIdx,
         List<HistoryKeyResultDto> krList
 ) {
     public static HistoryObjectiveListDto of(Objective objective) {

--- a/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveInvalidIndexException.java
+++ b/src/main/java/org/moonshot/server/domain/objective/exception/ObjectiveInvalidIndexException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.objective.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class ObjectiveInvalidIndexException extends MoonshotException {
+    public ObjectiveInvalidIndexException() {
+        super(ErrorType.INVALID_OBJECTIVE_INDEX);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/objective/model/IndexTarget.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/IndexTarget.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum IndexTarget {
 
+    OBJECTIVE("objective"),
     KEY_RESULT("keyResult"),
     TASK("task");
 

--- a/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
@@ -48,8 +48,7 @@ public class Objective {
     @Embedded
     private Period period;
 
-    @Column(columnDefinition = "smallint default -1")
-    private short idx;
+    private int idx;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -70,7 +69,7 @@ public class Objective {
         this.isClosed = false;
         this.heartCount = 0L;
         this.period = period;
-        this.idx = -1;
+        this.idx = 0;
         this.user = user;
         this.keyResultList = new ArrayList<>();
     }

--- a/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
+++ b/src/main/java/org/moonshot/server/domain/objective/model/Objective.java
@@ -91,4 +91,8 @@ public class Objective {
         this.progress = progress;
     }
 
+    public void modifyIdx(Integer idx) {
+        this.idx = idx;
+    }
+
 }

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveJpaRepository.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveJpaRepository.java
@@ -16,10 +16,17 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     Optional<Objective> findObjectiveAndUserById(@Param("objective_id") Long objectiveId);
     @Query("select distinct o from Objective o left join fetch o.keyResultList kr left join kr.taskList t where o.id = :objectiveId and o.isClosed = false and kr.id = t.keyResult.id")
     Optional<Objective> findByIdWithKeyResultsAndTasks(@Param("objectiveId") Long objectiveId);
-    @Query("select distinct o from Objective o where o.user.id = :userId and o.isClosed = false order by o.id desc")
+    @Query("select distinct o from Objective o where o.user.id = :userId and o.isClosed = false order by o.idx asc")
     List<Objective> findAllByUserId(@Param("userId") Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.user.id = :userId")
     void bulkUpdateIdxIncrease(@Param("userId") Long userId);
+    Long countAllByUserId(Long userId);
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.idx >= :lBound AND o.idx < :uBound AND o.user.id = :userId AND o.id != :targetId")
+    void bulkUpdateIdxIncrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("userId") Long userId, @Param("targetId") Long targetId);
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Objective o SET o.idx = o.idx - 1 WHERE o.idx >= :lBound AND o.idx <= :uBound AND o.user.id = :userId AND o.id != :targetId")
+    void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("userId") Long userId, @Param("targetId") Long targetId);
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveJpaRepository.java
+++ b/src/main/java/org/moonshot/server/domain/objective/repository/ObjectiveJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.moonshot.server.domain.objective.model.Objective;
 import org.moonshot.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,5 +18,8 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     Optional<Objective> findByIdWithKeyResultsAndTasks(@Param("objectiveId") Long objectiveId);
     @Query("select distinct o from Objective o where o.user.id = :userId and o.isClosed = false order by o.id desc")
     List<Objective> findAllByUserId(@Param("userId") Long userId);
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.user.id = :userId")
+    void bulkUpdateIdxIncrease(@Param("userId") Long userId);
 
 }

--- a/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/IndexTargetProvider.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class IndexTargetProvider {
 
     private static final Map<IndexTarget, IndexService> indexServiceMap = new HashMap<>();
+    private final ObjectiveService objectiveService;
     private final KeyResultService keyResultService;
     private final TaskService taskService;
 
@@ -22,6 +23,7 @@ public class IndexTargetProvider {
     void initIndexServiceMap() {
         indexServiceMap.put(IndexTarget.KEY_RESULT, keyResultService);
         indexServiceMap.put(IndexTarget.TASK, taskService);
+        indexServiceMap.put(IndexTarget.OBJECTIVE, objectiveService);
     }
 
     public IndexService getIndexService(IndexTarget indexTarget) {

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -42,9 +42,11 @@ public class ObjectiveService {
         User user =  userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        if (objectiveRepository.countAllByUserAndIsClosed(user, false) >= ACTIVE_OBJECTIVE_NUMBER) {
+        List<Objective> objectives = objectiveRepository.findAllByUserId(userId);
+        if (objectives.size() >= ACTIVE_OBJECTIVE_NUMBER) {
             throw new ObjectiveNumberExceededException();
         }
+        objectiveRepository.bulkUpdateIdxIncrease(userId);
 
         Objective newObjective = objectiveRepository.save(Objective.builder()
                 .title(request.objTitle())

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -127,16 +127,13 @@ public class ObjectiveService implements IndexService {
         } else {
             objectiveRepository.bulkUpdateIdxIncrease(request.idx(), prevIdx, userId, objective.getId());
         }
-
     }
 
     private boolean isInvalidIdx(Long objectiveCount, int idx) {
         return (objectiveCount <= idx) || (idx < 0);
-
     }
 
     private boolean isIndexIncreased(int prevIdx, int idx) {
         return prevIdx < idx;
-
     }
 }

--- a/src/main/java/org/moonshot/server/domain/task/exception/TaskInvalidIndexException.java
+++ b/src/main/java/org/moonshot/server/domain/task/exception/TaskInvalidIndexException.java
@@ -3,10 +3,10 @@ package org.moonshot.server.domain.task.exception;
 import org.moonshot.server.global.common.exception.MoonshotException;
 import org.moonshot.server.global.common.response.ErrorType;
 
-public class TaskInvalidPositionException extends MoonshotException {
+public class TaskInvalidIndexException extends MoonshotException {
 
-    public TaskInvalidPositionException() {
-        super(ErrorType.INVALID_TASK_ORDER);
+    public TaskInvalidIndexException() {
+        super(ErrorType.INVALID_TASK_INDEX);
     }
 
 }

--- a/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/moonshot/server/domain/task/repository/TaskRepository.java
@@ -13,6 +13,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     List<Task> findAllByKeyResult(KeyResult keyResult);
     List<Task> findAllByKeyResultOrderByIdx(KeyResult keyResult);
+    @Query("select count(t) from Task t join t.keyResult kr where kr.id = :keyResultId")
+    Long countAllByKeyResultId(@Param("keyResultId") Long keyResultId);
     @Query("select t from Task t join fetch t.keyResult kr join fetch kr.objective obj join fetch obj.user u where t.id = :taskId")
     Optional<Task> findTaskWithFetchJoin(@Param("taskId") Long taskId);
     @Modifying(clearAutomatically = true)

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -21,8 +21,9 @@ public enum ErrorType {
     ACTIVE_OBJECTIVE_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Objective 개수를 초과하였습니다"),
     ACTIVE_KEY_RESULT_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Key Result 개수를 초과하였습니다"),
     ACTIVE_TASK_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "허용된 Task 개수를 초과하였습니다."),
-    INVALID_KEY_RESULT_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
-    INVALID_TASK_ORDER(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
+    INVALID_OBJECTIVE_INDEX(HttpStatus.BAD_REQUEST, "정상적이지 않은 Objective 위치입니다."),
+    INVALID_KEY_RESULT_INDEX(HttpStatus.BAD_REQUEST, "정상적이지 않은 KeyResult 위치입니다."),
+    INVALID_TASK_INDEX(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
     INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "Log 입력값은 이전 값과 동일할 수 없습니다."),
     INVALID_EXPIRE_AT(HttpStatus.BAD_REQUEST, "Objective 종료 기간은 오늘보다 이전 날짜일 수 없습니다."),
 


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #110 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Objective 생성 시 Idx가 0이 되고 존재하는 Objective Idx를 하나씩 밀기
- Objective Idx 변경 로직 추가
- KeyResult, Task Index Validation(0~2) 비즈니스 로직으로 이동 -> Objective는 사이즈가 10까지라서 하나의 인터페이스를 구현하려면 이동하는 게 맞다고 판단
- IndexController Swagger 설정

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->

**Swagger 설정**
<img width="452" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/0f600829-3f28-4693-956e-517492ea7b4d">

**Index의 위치가 정상적이지 않을 때(Objective, KeyResult, Task 모두 동일)**
<img width="1136" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/e569ecfc-20b2-49e2-b66d-5e5447f2b9c9">

**Index의 위치가 정상적일 때(성공)**
<img width="1124" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/b2ad8a5e-ab46-4d3a-91b0-39ac0782528e">


