### PR TITLE
[Fix] #129 - 히스토리 조회 NPE 해결 및 OKR 데이터 생성 API KeyResult 기간 관련 예외처리

### DIFF
--- a/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidPeriodException.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/exception/KeyResultInvalidPeriodException.java
@@ -1,0 +1,10 @@
+package org.moonshot.server.domain.keyresult.exception;
+
+import org.moonshot.server.global.common.exception.MoonshotException;
+import org.moonshot.server.global.common.response.ErrorType;
+
+public class KeyResultInvalidPeriodException extends MoonshotException {
+    public KeyResultInvalidPeriodException() {
+        super(ErrorType.INVALID_KEY_RESULT_PERIOD);
+    }
+}

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -55,6 +55,7 @@ public class KeyResultService implements IndexService {
         for (KeyResultCreateRequestInfoDto dto : requests) {
             if (dto.startAt().isBefore(objective.getPeriod().getStartAt()) ||
                     dto.expireAt().isAfter(objective.getPeriod().getExpireAt()) ||
+                    dto.startAt().isAfter(objective.getPeriod().getExpireAt()) ||
                     dto.startAt().isAfter(dto.expireAt())) {
                 throw new KeyResultInvalidPeriodException();
             }

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -10,6 +10,7 @@ import org.moonshot.server.domain.keyresult.dto.request.KeyResultCreateRequestIn
 import org.moonshot.server.domain.keyresult.dto.request.KeyResultModifyRequestDto;
 import org.moonshot.server.domain.keyresult.dto.response.KRDetailResponseDto;
 import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidIndexException;
+import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidPeriodException;
 import org.moonshot.server.domain.keyresult.exception.KeyResultNotFoundException;
 import org.moonshot.server.domain.keyresult.exception.KeyResultNumberExceededException;
 import org.moonshot.server.domain.keyresult.model.KeyResult;
@@ -22,6 +23,7 @@ import org.moonshot.server.domain.log.model.LogState;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
 import org.moonshot.server.domain.log.repository.LogRepository;
 import org.moonshot.server.domain.log.service.LogService;
+import org.moonshot.server.domain.objective.exception.InvalidExpiredAtException;
 import org.moonshot.server.domain.objective.exception.ObjectiveNotFoundException;
 import org.moonshot.server.domain.objective.model.IndexService;
 import org.moonshot.server.domain.objective.model.Objective;
@@ -51,6 +53,11 @@ public class KeyResultService implements IndexService {
 
     public void createInitKRWithObjective(Objective objective, List<KeyResultCreateRequestInfoDto> requests) {
         for (KeyResultCreateRequestInfoDto dto : requests) {
+            if (dto.startAt().isBefore(objective.getPeriod().getStartAt()) ||
+                    dto.expireAt().isAfter(objective.getPeriod().getExpireAt()) ||
+                    dto.startAt().isAfter(dto.expireAt())) {
+                throw new KeyResultInvalidPeriodException();
+            }
             KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
                     .title(dto.title())
                     .period(Period.of(dto.startAt(), dto.expireAt()))

--- a/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
+++ b/src/main/java/org/moonshot/server/domain/keyresult/service/KeyResultService.java
@@ -23,7 +23,6 @@ import org.moonshot.server.domain.log.model.LogState;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
 import org.moonshot.server.domain.log.repository.LogRepository;
 import org.moonshot.server.domain.log.service.LogService;
-import org.moonshot.server.domain.objective.exception.InvalidExpiredAtException;
 import org.moonshot.server.domain.objective.exception.ObjectiveNotFoundException;
 import org.moonshot.server.domain.objective.model.IndexService;
 import org.moonshot.server.domain.objective.model.Objective;

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidPeriodException;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
 import org.moonshot.server.domain.objective.dto.request.ModifyObjectiveRequestDto;
@@ -122,10 +123,10 @@ public class ObjectiveService implements IndexService {
                 .map(entry -> ObjectiveGroupByYearDto.of(entry.getKey(), entry.getValue())).toList();
 
         List<ObjectiveGroupByYearDto> groupsSortedByCriteria;
-        if (criteria.equals(Criteria.LATEST)) {
+        if (criteria != null && criteria.equals(Criteria.LATEST)) {
             groupsSortedByCriteria = groupList.stream()
                     .sorted(Comparator.comparingInt(ObjectiveGroupByYearDto::year).reversed()).toList();
-        } else if (criteria.equals(Criteria.OLDEST)) {
+        } else if (criteria != null && criteria.equals(Criteria.OLDEST)) {
             groupsSortedByCriteria = groupList.stream()
                     .sorted(Comparator.comparingInt(ObjectiveGroupByYearDto::year)).toList();
         } else {

--- a/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
+++ b/src/main/java/org/moonshot/server/domain/objective/service/ObjectiveService.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.moonshot.server.domain.keyresult.exception.KeyResultInvalidPeriodException;
 import org.moonshot.server.domain.keyresult.service.KeyResultService;
 import org.moonshot.server.domain.objective.dto.request.ModifyIndexRequestDto;
 import org.moonshot.server.domain.objective.dto.request.ModifyObjectiveRequestDto;

--- a/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
+++ b/src/main/java/org/moonshot/server/global/common/response/ErrorType.java
@@ -27,6 +27,7 @@ public enum ErrorType {
     INVALID_TASK_INDEX(HttpStatus.BAD_REQUEST, "정상적이지 않은 Task 위치입니다."),
     INVALID_LOG_VALUE(HttpStatus.BAD_REQUEST, "Log 입력값은 이전 값과 동일할 수 없습니다."),
     INVALID_EXPIRE_AT(HttpStatus.BAD_REQUEST, "Objective 종료 기간은 오늘보다 이전 날짜일 수 없습니다."),
+    INVALID_KEY_RESULT_PERIOD(HttpStatus.BAD_REQUEST, "KeyResult 기간 설정이 Objective의 기간 내에 이루어지지 않습니다."),
     REQUIRED_EXPIRE_AT(HttpStatus.BAD_REQUEST, "기간 연장시 목표 종료 기간은 필수 입력값입니다."),
 
     /**


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #129 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 히스토리 조회 NPE 해결
- OKR 데이터 생성 API KeyResult 기간 관련 예외처리

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
<img width="1298" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/3c892a8c-f9ea-42b2-9306-2463dd367c30">


**예외 발생 시점**
```
if (dto.startAt().isBefore(objective.getPeriod().getStartAt()) ||
                    dto.expireAt().isAfter(objective.getPeriod().getExpireAt()) ||
                    dto.startAt().isAfter(dto.expireAt()))
```

1. Objective의 시작 날짜보다 KeyResult의 시작 날짜가 전일 때
2. Objective의 만료 날짜를 넘어서 KeyResult가 만료될 때
3. Objective의 만료 날짜를 넘어서 KeyResult가 시작할 때
4. KeyResult의 시작 날짜가 만료 날짜보다 이후일 때
