### PR TITLE
[Fix] #187 - 카카오 회원가입 시 디스코드 알림 안오는 이슈 해결

### DIFF
--- a/src/main/java/org/moonshot/server/domain/user/service/UserService.java
+++ b/src/main/java/org/moonshot/server/domain/user/service/UserService.java
@@ -180,7 +180,7 @@ public class UserService {
     public void sendDiscordAlert(User user) {
         try {
             DiscordAppender discordAppender = new DiscordAppender();
-            discordAppender.signInAppend(user.getName(), user.getEmail(), user.getSocialPlatform().getValue(), LocalDateTime.now());
+            discordAppender.signInAppend(user.getName(), user.getEmail() == null ? "" : user.getEmail(), user.getSocialPlatform().getValue(), LocalDateTime.now());
         } catch (ErrorLogAppenderException e) {
             log.error("{}", e.getErrorType().getMessage());
         }

--- a/src/main/java/org/moonshot/server/global/constants/JWTConstants.java
+++ b/src/main/java/org/moonshot/server/global/constants/JWTConstants.java
@@ -3,7 +3,7 @@ package org.moonshot.server.global.constants;
 public class JWTConstants {
 
     public static final String USER_ID = "userId";
-    public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2;
+    public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L * 1;
     public static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2; 
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #187

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 카카오 회원가입 시 디스코드 알림 안오는 이슈 해결
- DiscordAppender에서 유저 이메일까지 넣어주고 있는데 카카오 회원가입의 경우 email값이 null이라 디스코드 알림에 실패하여서 해당 부분을 삼항연산자로 뺴서 email이 없는 경우 빈 문자열을 넣어주도록 수정하였습니다!

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
