### PR TITLE
[Feat] #202 - Task 삭제 API 구현

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/task/controller/TaskApi.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/controller/TaskApi.java
@@ -13,6 +13,7 @@ import java.security.Principal;
 import org.moonshot.response.MoonshotResponse;
 import org.moonshot.task.dto.request.TaskSingleCreateRequestDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Task", description = "Task 관련 API")
@@ -27,6 +28,15 @@ public interface TaskApi {
     public ResponseEntity<MoonshotResponse<?>> createTask(Principal principal,
                                                           @Parameter(in = ParameterIn.DEFAULT, name = "TaskSingleCreateRequest", description = "task 추가 요청 body")
                                                           @RequestBody @Valid TaskSingleCreateRequestDto request);
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = ""),
+            @ApiResponse(responseCode = "403", description = "해당 자원에 접근 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 Task입니다.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MoonshotResponse.class)))
+    })
+    @Operation(summary = "Task 삭제")
+    public ResponseEntity<?> deleteTask(Principal principal, @PathVariable("taskId") Long taskId);
 }
 
 

--- a/moonshot-api/src/main/java/org/moonshot/task/controller/TaskController.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/controller/TaskController.java
@@ -27,7 +27,7 @@ public class TaskController implements TaskApi {
     }
 
     @DeleteMapping("/{taskId}")
-    public ResponseEntity<?> deleteTask (final Principal principal, @PathVariable("taskId") final long taskId) {
+    public ResponseEntity<?> deleteTask (final Principal principal, @PathVariable("taskId") final Long taskId) {
         taskService.deleteTask(JwtTokenProvider.getUserIdFromPrincipal(principal), taskId);
         return ResponseEntity.noContent().build();
     }

--- a/moonshot-api/src/main/java/org/moonshot/task/controller/TaskController.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/controller/TaskController.java
@@ -11,10 +11,7 @@ import org.moonshot.task.dto.request.TaskSingleCreateRequestDto;
 import org.moonshot.task.service.TaskService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +24,12 @@ public class TaskController implements TaskApi {
     public ResponseEntity<MoonshotResponse<?>> createTask(final Principal principal, @RequestBody @Valid final TaskSingleCreateRequestDto request) {
         taskService.createTask(request, JwtTokenProvider.getUserIdFromPrincipal(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(MoonshotResponse.success(POST_TASK_SUCCESS));
+    }
+
+    @DeleteMapping("/{taskId}")
+    public ResponseEntity<?> deleteTask (final Principal principal, @PathVariable("taskId") final long taskId) {
+        taskService.deleteTask(JwtTokenProvider.getUserIdFromPrincipal(principal), taskId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -94,7 +94,7 @@ public class TaskService implements IndexService {
         return (taskCount <= idx) || (idx < 0);
     }
 
-    public void deleteTask(final Long userId, long taskId) {
+    public void deleteTask(final Long userId, Long taskId) {
         Task task = taskRepository.findTaskWithFetchJoin(taskId)
                         .orElseThrow(TaskNotFoundException::new);
         userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -94,4 +94,10 @@ public class TaskService implements IndexService {
         return (taskCount <= idx) || (idx < 0);
     }
 
+    public void deleteTask(final Long userId, long taskId) {
+        Task task = taskRepository.findTaskWithFetchJoin(taskId)
+                        .orElseThrow(TaskNotFoundException::new);
+        userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);
+        taskRepository.deleteById(taskId);
+    }
 }

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -100,4 +100,5 @@ public class TaskService implements IndexService {
         userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);
         taskRepository.deleteById(taskId);
     }
+    
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #202 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Task 관련 API 작업 진행하였습니다. 기존에 Task 추가 API가 있어서 삭제만 추가적으로 구현했고 수정API는 기획 측에 물어보고 작업 진행하겠습니다!
- 노션 API 명세서와 Swagger도 추가했습니다!
- API 테스트 결과는 다음과 같습니다!
<img width="745" alt="스크린샷 2024-02-20 오후 4 06 08" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/bdac44e1-adb7-4ffa-9f6d-3b4b2bec0e7c">
<img width="363" alt="스크린샷 2024-02-20 오후 3 46 26" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/6bbef6f2-9f92-4ca9-830f-0b20b881699a">
<img width="438" alt="스크린샷 2024-02-20 오후 3 46 18" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/3f39f243-7375-4009-8094-b251d9ad208b">


### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
