### PR TITLE
[Feat] #214 - 회원탈퇴 SoftDelete 구현

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/config/SchedulerConfig.java
+++ b/moonshot-api/src/main/java/org/moonshot/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package org.moonshot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
+++ b/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
@@ -111,6 +111,14 @@ public class KeyResultService implements IndexService {
         keyResultRepository.deleteAllInBatch(krList);
     }
 
+
+    public void deleteAllKeyResult(List<Objective> objectiveList) {
+        List<KeyResult> keyResultList = keyResultRepository.findAllByObjectiveIn(objectiveList);
+        logRepository.deleteAllInBatch(logRepository.findAllByKeyResultIn(keyResultList));
+        taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResultIn(keyResultList));
+        keyResultRepository.deleteAllInBatch(keyResultList);
+    }
+
     public Optional<AchieveResponseDto> modifyKeyResult(final KeyResultModifyRequestDto request, final Long userId) {
         KeyResult keyResult = keyResultRepository.findKeyResultAndObjective(request.keyResultId())
                 .orElseThrow(KeyResultNotFoundException::new);

--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -22,10 +22,7 @@ import org.moonshot.objective.dto.request.OKRCreateRequestDto;
 import org.moonshot.objective.dto.response.DashboardResponseDto;
 import org.moonshot.objective.dto.response.HistoryResponseDto;
 import org.moonshot.objective.dto.response.ObjectiveGroupByYearDto;
-import org.moonshot.objective.model.Category;
-import org.moonshot.objective.model.Criteria;
-import org.moonshot.objective.model.IndexService;
-import org.moonshot.objective.model.Objective;
+import org.moonshot.objective.model.*;
 import org.moonshot.objective.repository.ObjectiveRepository;
 import org.moonshot.user.model.User;
 import org.moonshot.user.repository.UserRepository;
@@ -71,6 +68,16 @@ public class ObjectiveService implements IndexService {
         keyResultService.deleteKeyResult(objective);
         objectiveRepository.delete(objective);
         return getObjectiveInDashboard(userId, null);
+    }
+
+    public void deleteAllObjective(final Long userId) {
+        List<Objective> objectiveList = objectiveRepository.findAllByUser(userId);
+        objectiveList.forEach((objective) -> {
+            validateUserAuthorization(objective.getUser().getId(), userId);
+
+            keyResultService.deleteKeyResult(objective);
+            objectiveRepository.delete(objective);
+        });
     }
 
     public void modifyObjective(final Long userId, final ModifyObjectiveRequestDto request) {

--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -70,14 +70,10 @@ public class ObjectiveService implements IndexService {
         return getObjectiveInDashboard(userId, null);
     }
 
-    public void deleteAllObjective(final Long userId) {
-        List<Objective> objectiveList = objectiveRepository.findAllByUser(userId);
-        objectiveList.forEach((objective) -> {
-            validateUserAuthorization(objective.getUser().getId(), userId);
-
-            keyResultService.deleteKeyResult(objective);
-            objectiveRepository.delete(objective);
-        });
+    public void deleteAllObjective(final List<User> userList) {
+        List<Objective> objectiveList = objectiveRepository.findAllByUserIn(userList);
+        keyResultService.deleteAllKeyResult(objectiveList);
+        objectiveRepository.deleteAllInBatch(objectiveList);
     }
 
     public void modifyObjective(final Long userId, final ModifyObjectiveRequestDto request) {

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -27,7 +27,7 @@ public class TaskService implements IndexService {
 
     private final KeyResultRepository keyResultRepository;
     private final TaskRepository taskRepository;
-    private final UserService userService;
+//    private final UserService userService;
 
     public void createTask(final TaskSingleCreateRequestDto request, final Long userId) {
         KeyResult keyResult = keyResultRepository.findKeyResultAndObjective(request.keyResultId())
@@ -72,7 +72,9 @@ public class TaskService implements IndexService {
     public void modifyIdx(final ModifyIndexRequestDto request, final Long userId) {
         Task task = taskRepository.findTaskWithFetchJoin(request.id())
                 .orElseThrow(TaskNotFoundException::new);
-        userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);
+        if (task.getKeyResult().getObjective().getUser().getId().equals(userId)) {
+            throw new AccessDeniedException();
+        }
         Long taskCount = taskRepository.countAllByKeyResultId(task.getKeyResult().getId());
         if (isInvalidIdx(taskCount, request.idx())) {
             throw new KeyResultInvalidIndexException();
@@ -97,7 +99,9 @@ public class TaskService implements IndexService {
     public void deleteTask(final Long userId, Long taskId) {
         Task task = taskRepository.findTaskWithFetchJoin(taskId)
                         .orElseThrow(TaskNotFoundException::new);
-        userService.validateUserAuthorization(task.getKeyResult().getObjective().getUser(), userId);
+        if (task.getKeyResult().getObjective().getUser().getId().equals(userId)) {
+            throw new AccessDeniedException();
+        }
         taskRepository.deleteById(taskId);
     }
     

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -27,7 +27,6 @@ public class TaskService implements IndexService {
 
     private final KeyResultRepository keyResultRepository;
     private final TaskRepository taskRepository;
-//    private final UserService userService;
 
     public void createTask(final TaskSingleCreateRequestDto request, final Long userId) {
         KeyResult keyResult = keyResultRepository.findKeyResultAndObjective(request.keyResultId())

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserDeleteScheduler.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserDeleteScheduler.java
@@ -1,7 +1,6 @@
 package org.moonshot.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.moonshot.user.repository.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +14,9 @@ public class UserDeleteScheduler {
 
     private final UserService userService;
 
-    @Scheduled(cron="0/10 * * * * *")   //10초에 한번씩 실행
+    @Scheduled(cron="0 0 2 * * ?")
     public void deleteUser() {
         userService.softDeleteUser(LocalDateTime.now());
     }
+
 }

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserDeleteScheduler.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserDeleteScheduler.java
@@ -1,0 +1,22 @@
+package org.moonshot.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.moonshot.user.repository.UserRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class UserDeleteScheduler {
+
+    private final UserService userService;
+
+    @Scheduled(cron="0/10 * * * * *")   //10초에 한번씩 실행
+    public void deleteUser() {
+        userService.softDeleteUser(LocalDateTime.now());
+    }
+}

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
@@ -155,7 +155,6 @@ public class UserService {
         User user =  userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         user.setDeleteAt();
-//        softDeleteUser();
     }
 
     public void modifyProfile(final Long userId, final UserInfoRequest request) {
@@ -193,14 +192,10 @@ public class UserService {
 
     public void softDeleteUser(LocalDateTime currentDate) {
         List<User> expiredUserList = userRepository.findIdByDeletedAtBefore(currentDate);
-        cascadeDelete(expiredUserList);
-        userRepository.deleteAll(expiredUserList);
-    }
-
-    private void cascadeDelete(final List<User> expiredUserList) {
-        expiredUserList.forEach((user) -> {
-            objectiveService.deleteAllObjective(user.getId());
-        });
+        if(!expiredUserList.isEmpty()) {
+            objectiveService.deleteAllObjective(expiredUserList);
+            userRepository.deleteAllInBatch(expiredUserList);
+        }
     }
 
 }

--- a/moonshot-api/src/main/resources/db/migration/V2__add_deleteAt_field.sql
+++ b/moonshot-api/src/main/resources/db/migration/V2__add_deleteAt_field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user DROP COLUMN is_deleted;
+ALTER TABLE user ADD COLUMN delete_at DATETIME(6);

--- a/moonshot-domain/src/main/java/org/moonshot/keyresult/repository/KeyResultRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/keyresult/repository/KeyResultRepository.java
@@ -26,5 +26,6 @@ public interface KeyResultRepository extends JpaRepository<KeyResult, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE KeyResult kr SET kr.idx = kr.idx - 1 WHERE kr.idx >= :lBound AND kr.idx <= :uBound AND kr.objective.id = :objectiveId AND kr.id != :targetId")
     void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("objectiveId") Long objectiveId, @Param("targetId") Long targetId);
+    List<KeyResult> findAllByObjectiveIn(List<Objective> objectiveList);
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/log/repository/LogRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/log/repository/LogRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.moonshot.keyresult.model.KeyResult;
 import org.moonshot.log.model.Log;
 import org.moonshot.log.model.LogState;
+import org.moonshot.objective.model.Objective;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,8 +14,8 @@ public interface LogRepository extends JpaRepository<Log, Long> {
 
     List<Log> findAllByKeyResult(KeyResult keyResult);
     List<Log> findAllByKeyResultOrderByIdDesc(KeyResult keyResult);
-
     @Query("select l FROM Log l JOIN FETCH l.keyResult k WHERE l.state = :state and l.keyResult.id = :keyResultId ORDER BY l.id DESC LIMIT 1")
     Optional<Log> findLatestLogByKeyResultId(@Param("state") LogState state, @Param("keyResultId") Long keyResultId);
+    List<Log> findAllByKeyResultIn(List<KeyResult> keyResultList);
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
@@ -18,6 +18,8 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     Optional<Objective> findByIdWithKeyResultsAndTasks(@Param("objectiveId") Long objectiveId);
     @Query("select distinct o from Objective o join fetch o.user where o.user.id = :userId and o.isClosed = false order by o.idx asc")
     List<Objective> findAllByUserId(@Param("userId") Long userId);
+    @Query("select distinct o from Objective o join fetch o.user where o.user.id = :userId")
+    List<Objective> findAllByUser(@Param("userId") Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.user.id = :userId")
     void bulkUpdateIdxIncrease(@Param("userId") Long userId);

--- a/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
@@ -2,6 +2,8 @@ package org.moonshot.objective.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import org.moonshot.keyresult.model.KeyResult;
 import org.moonshot.objective.model.Objective;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,8 +20,6 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     Optional<Objective> findByIdWithKeyResultsAndTasks(@Param("objectiveId") Long objectiveId);
     @Query("select distinct o from Objective o join fetch o.user where o.user.id = :userId and o.isClosed = false order by o.idx asc")
     List<Objective> findAllByUserId(@Param("userId") Long userId);
-    @Query("select distinct o from Objective o join fetch o.user where o.user.id = :userId")
-    List<Objective> findAllByUser(@Param("userId") Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.user.id = :userId")
     void bulkUpdateIdxIncrease(@Param("userId") Long userId);
@@ -30,5 +30,6 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx - 1 WHERE o.idx >= :lBound AND o.idx <= :uBound AND o.user.id = :userId AND o.id != :targetId")
     void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("userId") Long userId, @Param("targetId") Long targetId);
+    List<Objective> findAllByUserIn(List<User> userList);
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/task/repository/TaskRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/task/repository/TaskRepository.java
@@ -3,6 +3,7 @@ package org.moonshot.task.repository;
 import java.util.List;
 import java.util.Optional;
 import org.moonshot.keyresult.model.KeyResult;
+import org.moonshot.log.model.Log;
 import org.moonshot.task.model.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -23,5 +24,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE Task t SET t.idx = t.idx - 1 WHERE t.idx >= :lBound AND t.idx <= :uBound AND t.keyResult.id = :keyResultId AND t.id != :targetId")
     void bulkUpdateTaskIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("keyResultId") Long keyResultId, @Param("targetId") Long targetId);
+    List<Task> findAllByKeyResultIn(List<KeyResult> keyResultList);
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/SocialPlatform.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/SocialPlatform.java
@@ -9,8 +9,7 @@ import lombok.Getter;
 public enum SocialPlatform {
 
     KAKAO("kakao"),
-    GOOGLE("google"),
-    WITHDRAWAL("withdrawal");
+    GOOGLE("google");
 
     private final String value;
 

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
@@ -55,7 +55,7 @@ public class User {
     }
 
     @Builder(builderMethodName = "builderWithSignIn")
-    public static User of(String socialId, SocialPlatform socialPlatform, String name, String profileImage, String email, Boolean isDeleted) {
+    public static User of(String socialId, SocialPlatform socialPlatform, String name, String profileImage, String email) {
         return builder()
                 .socialId(socialId)
                 .socialPlatform(socialPlatform)

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
@@ -3,6 +3,9 @@ package org.moonshot.user.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,7 +37,7 @@ public class User {
 
     private String description;
 
-    private boolean isDeleted;
+    private LocalDateTime deleteAt;
 
     @Builder
     private User(String socialId, SocialPlatform socialPlatform, String name, String profileImage, String email,
@@ -49,7 +52,7 @@ public class User {
     }
 
     @Builder(builderMethodName = "builderWithSignIn")
-    public static User of(String socialId, SocialPlatform socialPlatform, String name, String profileImage, String email) {
+    public static User of(String socialId, SocialPlatform socialPlatform, String name, String profileImage, String email, Boolean isDeleted) {
         return builder()
                 .socialId(socialId)
                 .socialPlatform(socialPlatform)
@@ -59,12 +62,15 @@ public class User {
                 .build();
     }
 
-    public void modifySocialPlatform(SocialPlatform socialPlatform) {
-        this.socialPlatform = socialPlatform;
-    }
-
     public void modifyNickname(String nickname) { this.nickname = nickname; }
 
     public void modifyDescription(String description) { this.description = description; }
+
+    public void resetDeleteAt() {
+        this.deleteAt = null;
+    }
+    public void setDeleteAt(){
+        this.deleteAt = LocalDateTime.now().plusMinutes(3);
+    }
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Builder(builderMethodName = "buildWithId")
 public class User {
 
+    // TODO 기획 측 약관 확정 이후 수정 필요
+    private static final Long USER_RETENTION_PERIOD = 14L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -70,7 +73,7 @@ public class User {
         this.deleteAt = null;
     }
     public void setDeleteAt(){
-        this.deleteAt = LocalDateTime.now().plusMinutes(3);
+        this.deleteAt = LocalDateTime.now().plusDays(USER_RETENTION_PERIOD);
     }
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserRepository.java
@@ -1,14 +1,22 @@
 package org.moonshot.user.repository;
 
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.moonshot.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findUserBySocialId(String socialId);
     Optional<User> findUserByNickname(String nickname);
+
+    @Query("SELECT u FROM User u WHERE u.deleteAt < :currentDate")
+    List<User> findIdByDeletedAtBefore(LocalDateTime currentDate);
 
 }
 


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #214

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
-  회원탈퇴 SoftDelete 구현했습니다.
- 기존 존재했던 isDeleted 필드를 없애고 deleteAt 필드를 추가하였습니다. 회원탈퇴 후 Retention 기간 내 재가입시 deleteAt을 null로 바꾸어 주었습니다.
- 회원탈퇴 로직은 다음과 같습니다!
```
1. Scheduler를 통해 매일 새벽 2시에 삭제해야할 UserList를 전체 조회
2. UserList와 관련 ObjectiveList 조회 후 ObjectiveService로 넘김
3. Objective를 넘겨받은 ObjectiveService는 해당 Objective들과 관련된 KeyResultList 조회 후 KeyResultService로 요청 
4. KeyResultService는 해당 KeyResult들과 관련된 TaskList와 LogList  조회
5. 각 Service에서 List로 조회되어 있는 엔티티들 deleteAllInBatch 메소드로 삭제 진행

**  UserList에 User가 있는 경우에 2-5 단계 진행
```

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- Flyway 통해서 DB Migration Test 진행 완료하였습니다. DB 변경할 때마다 baseline-version 변경 및 flyway-history 테이블이 존재하는 경우 `baseline-on-migrate: false` 로 지정해야한다고 합니다!
- taskService에서 해당 부분을 임시로 변경해두었습니다.. 다음 이슈에서 Validator 분리하여 작업 예정입니다!
- select 쿼리 5번, delete 쿼리 5번 날아가는데 더 줄일 수 있는 쿼리가 있으면 코드리뷰 부탁드립니다~!
