### PR TITLE
[Refactor] #238 - Discord 회원가입 로직 이벤트 Pub-Sub 구조로 리팩토링

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
+++ b/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
@@ -1,6 +1,15 @@
 package org.moonshot.keyresult.service;
 
-import static org.moonshot.keyresult.service.validator.KeyResultValidator.*;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.hasChange;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.hasDateChange;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.hasKeyResultTask;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.isKeyResultAchieved;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateActiveKRSizeExceeded;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateIndex;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateIndexUnderMaximum;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateKRPeriodWithInObjPeriod;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateKeyResultIndex;
+import static org.moonshot.keyresult.service.validator.KeyResultValidator.validateKeyResultPeriod;
 import static org.moonshot.log.service.validator.LogValidator.validateLogNum;
 import static org.moonshot.task.service.validator.TaskValidator.validateTaskIndex;
 import static org.moonshot.user.service.validator.UserValidator.validateUserAuthorization;
@@ -15,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 import org.moonshot.common.model.Period;
 import org.moonshot.exception.keyresult.KeyResultNotFoundException;
 import org.moonshot.exception.keyresult.KeyResultRequiredException;
-import org.moonshot.exception.log.LogNotFoundException;
 import org.moonshot.exception.objective.ObjectiveNotFoundException;
 import org.moonshot.keyresult.dto.request.KeyResultCreateRequestDto;
 import org.moonshot.keyresult.dto.request.KeyResultCreateRequestInfoDto;
@@ -92,7 +100,7 @@ public class KeyResultService implements IndexService {
                 .idx(request.idx())
                 .target(request.target())
                 .metric(request.metric()).build());
-      logService.createKRLog(request, keyResult.getId());
+        logService.createKRLog(request, keyResult.getId());
     }
 
     public void deleteKeyResult(final Long keyResultId, final Long userId) {

--- a/moonshot-external/src/main/java/org/moonshot/discord/DiscordAppender.java
+++ b/moonshot-external/src/main/java/org/moonshot/discord/DiscordAppender.java
@@ -18,9 +18,11 @@ import org.moonshot.discord.model.EmbedObject;
 import org.moonshot.exception.global.external.discord.ErrorLogAppenderException;
 import org.moonshot.util.MDCUtil;
 import org.moonshot.util.StringUtil;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Setter
+@Component
 @RequiredArgsConstructor
 public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 

--- a/moonshot-external/src/main/java/org/moonshot/discord/SignUpEvent.java
+++ b/moonshot-external/src/main/java/org/moonshot/discord/SignUpEvent.java
@@ -1,0 +1,13 @@
+package org.moonshot.discord;
+
+
+import java.time.LocalDateTime;
+
+public record SignUpEvent(String name, String email, String socialPlatform, LocalDateTime createdAt, String imageUrl) {
+
+    public static SignUpEvent of(String name, String email, String socialPlatform, LocalDateTime createdAt,
+                                 String imageUrl) {
+        return new SignUpEvent(name, email, socialPlatform, createdAt, imageUrl);
+    }
+
+}

--- a/moonshot-external/src/main/java/org/moonshot/discord/SignUpEventListener.java
+++ b/moonshot-external/src/main/java/org/moonshot/discord/SignUpEventListener.java
@@ -1,0 +1,23 @@
+package org.moonshot.discord;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SignUpEventListener {
+
+    private final DiscordAppender discordAppender;
+
+    @EventListener
+    public void handleSignUpEvent(SignUpEvent event) {
+        discordAppender.signInAppend(
+                event.name(),
+                event.email(),
+                event.socialPlatform(),
+                event.createdAt(),
+                event.imageUrl());
+    }
+
+}

--- a/moonshot-external/src/main/java/org/moonshot/discord/SignUpEventListener.java
+++ b/moonshot-external/src/main/java/org/moonshot/discord/SignUpEventListener.java
@@ -1,10 +1,12 @@
 package org.moonshot.discord;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("prod")
 @RequiredArgsConstructor
 public class SignUpEventListener {
 


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #238 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- UserService에서 DiscordAppender의 의존성이 직접적으로 사용되는 것을 고쳤습니다.
- 유저가 회원가입 시 DiscordAppender.signInAppend() 메소드를 직접 호출하는 방식을 제거하고 SignUpEvent를 만들었습니다.

흐름은 다음과 같습니다.
- UserService에서 ApplicationEventPublisher(ApplicationContext 가 구현해줘서 주입받아 그냥 사용하면 됨)를 주입받아 eventPublisher.publishEvent(new SignUpEvent()); 를 호출합니다.
- moonshot-external 모듈에 있는 discord 패키지에 SignUpEventListener를 만들고 해당 리스너에서 이벤트를 구독합니다.
- 해당 이벤트를 구독하고 의존성으로 주입되어 있는 DiscordAppender.signInAppend() 메소드를 호출합니다.

이로서 얻는 이점
- UserService와 DiscordAppender(알림 서비스) 와의 강한 결합도를 느슨하게 만들었습니다.

단점
- 로직의 흐름을 직접적으로 파악하기 어려울 수 있으니 코드리뷰하시고 이해가 안되는 부분은 리뷰 달아주세요!~~

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
