### PR TITLE
[Refactor] #240 - 로그인 로직 리팩토링

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/user/controller/UserApi.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/controller/UserApi.java
@@ -66,8 +66,4 @@ public interface UserApi {
     @Operation(summary = "프로필 조회")
     public ResponseEntity<MoonshotResponse<UserInfoResponse>> getMyProfile(@LoginUser Long userId);
 
-    @ApiResponse(responseCode = "200", description = "구글 로그인에 성공하였습니다.")
-    @Operation(summary = "구글 로그인")
-    public String authTest(HttpServletRequest request, HttpServletResponse response);
-
 }

--- a/moonshot-api/src/main/java/org/moonshot/user/controller/UserController.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/controller/UserController.java
@@ -33,15 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/user")
 public class UserController implements UserApi {
 
-    @Value("${google.client-id}")
-    private String googleClientId;
-
-    @Value("${google.client-secret}")
-    private String googleClientSecret;
-
-    @Value("${google.redirect-url}")
-    private String googleRedirectUrl;
-
     private final UserService userService;
 
     @PostMapping("/login")
@@ -82,20 +73,6 @@ public class UserController implements UserApi {
     @Logging(item = "User", action = "Get")
     public ResponseEntity<MoonshotResponse<UserInfoResponse>> getMyProfile(@LoginUser Long userId) {
         return ResponseEntity.ok(MoonshotResponse.success(SuccessType.GET_PROFILE_SUCCESS, userService.getMyProfile(userId)));
-    }
-
-    @GetMapping("/googleLogin")
-    @Logging(item = "User", action = "Get")
-    public String authTest(final HttpServletRequest request, final HttpServletResponse response) {
-        String redirectURL = "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + googleClientId
-                + "&redirect_uri=" + googleRedirectUrl + "&response_type=code&scope=email profile";
-        try {
-            response.sendRedirect(redirectURL);
-        } catch (Exception e) {
-            log.info("authTest = {}", e);
-        }
-
-        return "SUCCESS";
     }
 
 }

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
@@ -76,7 +76,7 @@ public class UserService {
         };
     }
 
-    public SocialLoginResponse googleLogin(final SocialLoginRequest request) throws IOException {
+    public SocialLoginResponse googleLogin(final SocialLoginRequest request) {
         GoogleTokenResponse tokenResponse = googleAuthApiClient.googleAuth(
                 request.code(),
                 googleClientId,

--- a/moonshot-auth/src/main/java/org/moonshot/jwt/JwtValidationType.java
+++ b/moonshot-auth/src/main/java/org/moonshot/jwt/JwtValidationType.java
@@ -1,7 +1,8 @@
 package org.moonshot.jwt;
 
 public enum JwtValidationType {
-    VALID_JWT,
+    VALID_ACCESS,
+    VALID_REFRESH,
     INVALID_JWT_SIGNATURE,
     INVALID_JWT_TOKEN,
     EXPIRED_JWT_TOKEN,

--- a/moonshot-auth/src/main/java/org/moonshot/security/JwtAuthenticationFilter.java
+++ b/moonshot-auth/src/main/java/org/moonshot/security/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.moonshot.constants.JWTConstants;
 import org.moonshot.constants.WhiteListConstants;
 import org.moonshot.jwt.JwtTokenProvider;
 import org.moonshot.jwt.JwtValidationType;
@@ -33,11 +34,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
         final String token = getJwtFromRequest(request);
-        if (jwtTokenProvider.validateAccessToken(token) == JwtValidationType.VALID_JWT) {
-            Long userId = jwtTokenProvider.getUserFromJwt(token);
-            Authentication authentication = jwtTokenProvider.getAuthentication(userId);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
+        jwtTokenProvider.validateToken(token);
+
+        Long userId = jwtTokenProvider.getUserFromJwt(token);
+        Authentication authentication = jwtTokenProvider.getAuthentication(userId);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
         filterChain.doFilter(request, response);
     }
 

--- a/moonshot-common/src/main/java/org/moonshot/constants/JWTConstants.java
+++ b/moonshot-common/src/main/java/org/moonshot/constants/JWTConstants.java
@@ -3,6 +3,9 @@ package org.moonshot.constants;
 public class JWTConstants {
 
     public static final String USER_ID = "userId";
+    public static final String TOKEN_TYPE = "type";
+    public static final String ACCESS_TOKEN = "access";
+    public static final String REFRESH_TOKEN = "refresh";
     public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 1000L * 20;
     public static final Long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 1000L * 60 * 24 * 7 * 2; 
 

--- a/moonshot-common/src/main/java/org/moonshot/exception/global/auth/InvalidRefreshTokenException.java
+++ b/moonshot-common/src/main/java/org/moonshot/exception/global/auth/InvalidRefreshTokenException.java
@@ -5,6 +5,6 @@ import org.moonshot.response.ErrorType;
 
 public class InvalidRefreshTokenException extends MoonshotException {
     public InvalidRefreshTokenException() {
-        super(ErrorType.INVALID_REFRESHTOKEN_ERROR);
+        super(ErrorType.INVALID_REFRESH_TOKEN_ERROR);
     }
 }

--- a/moonshot-common/src/main/java/org/moonshot/response/ErrorType.java
+++ b/moonshot-common/src/main/java/org/moonshot/response/ErrorType.java
@@ -38,7 +38,7 @@ public enum ErrorType {
     INVALID_AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 코드입니다."),
     UNSUPPORTED_TOKEN_ERROR(HttpStatus.UNAUTHORIZED,"지원하지 않는 토큰 방식입니다."),
     INVALID_ACCESS_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 AccessToken입니다."),
-    INVALID_REFRESHTOKEN_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 RefreshToken입니다."),
+    INVALID_REFRESH_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 RefreshToken입니다."),
     INVALID_AUTH_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     EXPIRED_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "만료된 Token입니다."),
     WRONG_TYPE_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "잘못된 형식의 Token입니다"),


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #240 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- 기존 엑세스토큰과 리프레쉬토큰이 같은 역할을 하고 있어 토큰 역할을 분리해주었습니다. 
- 구글로그인에서 /googleLogin으로 접속하면 서버 측에서 보내주는 방식이였는데 해당 부분을 카카오 로그인과 동일하게 클라이언트 측에서 처리하도록 변경하며 더 이상 사용되지 않는 /googleLogin을 없앴습니다~

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
