### PR TITLE
[Fix] KeyResult, Task 생성, 삭제 시 Index 위치 조정 로직 변경

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
+++ b/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
@@ -92,9 +92,8 @@ public class KeyResultService implements IndexService {
         validateActiveKRSizeExceeded(krList.size());
         validateIndexUnderMaximum(request.idx(), krList.size());
 
-        for (int i = request.idx(); i < krList.size(); i++) {
-            krList.get(i).incrementIdx();
-        }
+        keyResultRepository.bulkUpdateIdxIncrease(request.idx(), krList.size(), objective.getId(), -1L);
+
         KeyResult keyResult = keyResultRepository.save(KeyResult.builder()
                 .objective(objective)
                 .title(request.title())

--- a/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
+++ b/moonshot-api/src/main/java/org/moonshot/keyresult/service/KeyResultService.java
@@ -112,6 +112,7 @@ public class KeyResultService implements IndexService {
         logRepository.deleteAllInBatch(logRepository.findAllByKeyResult(keyResult));
         taskRepository.deleteAllInBatch(taskRepository.findAllByKeyResult(keyResult));
         keyResultRepository.delete(keyResult);
+        keyResultRepository.bulkUpdateIdxDecrease(keyResult.getIdx(), 3, keyResult.getObjective().getId(), -1L);
     }
 
     public void deleteKeyResult(final Objective objective) {

--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -71,6 +71,8 @@ public class ObjectiveService implements IndexService {
 
         keyResultService.deleteKeyResult(objective);
         objectiveRepository.delete(objective);
+        objectiveRepository.bulkUpdateIdxDecreaseAfter(objective.getIdx(), userId);
+
         return getObjectiveInDashboard(userId, null);
     }
 

--- a/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/TaskService.java
@@ -39,9 +39,8 @@ public class TaskService implements IndexService {
         validateActiveTaskSizeExceeded(taskList.size());
         validateIndexUnderMaximum(request.idx(), taskList.size());
 
-        for (int i = request.idx(); i < taskList.size(); i++) {
-            taskList.get(i).incrementIdx();
-        }
+        taskRepository.bulkUpdateTaskIdxIncrease(request.idx(), taskList.size(), keyResult.getId(), -1L);
+
         saveTask(keyResult, request);
     }
 
@@ -90,6 +89,7 @@ public class TaskService implements IndexService {
         validateUserAuthorization(task.getKeyResult().getObjective().getUser().getId(), userId);
 
         taskRepository.deleteById(taskId);
+        taskRepository.bulkUpdateTaskIdxDecrease(task.getIdx(), 3, task.getKeyResult().getId(), -1L);
     }
     
 }

--- a/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
 
-    Long countAllByUserAndIsClosed(User user, boolean isClosed);
     @Query("select o from Objective o join fetch o.user where o.id = :objective_id")
     Optional<Objective> findObjectiveAndUserById(@Param("objective_id") Long objectiveId);
     @Query("select distinct o from Objective o left join fetch o.keyResultList kr left join kr.taskList t where o.id = :objectiveId and o.isClosed = false")
@@ -21,7 +20,6 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.user.id = :userId")
     void bulkUpdateIdxIncrease(@Param("userId") Long userId);
-    Long countAllByUserId(Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx + 1 WHERE o.idx >= :lBound AND o.idx < :uBound AND o.user.id = :userId AND o.id != :targetId")
     void bulkUpdateIdxIncrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("userId") Long userId, @Param("targetId") Long targetId);
@@ -32,5 +30,6 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     @Query("UPDATE Objective  o SET o.idx = o.idx - 1 WHERE o.idx >= :lBound AND o.user.id = :userId")
     void bulkUpdateIdxDecreaseAfter(@Param("lBound") int lowerBound, @Param("userId") Long userId);
     List<Objective> findAllByUserIn(List<User> userList);
+    Long countAllByUserId(Long userId);
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveJpaRepository.java
@@ -2,14 +2,12 @@ package org.moonshot.objective.repository;
 
 import java.util.List;
 import java.util.Optional;
-
-import org.moonshot.keyresult.model.KeyResult;
 import org.moonshot.objective.model.Objective;
+import org.moonshot.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.moonshot.user.model.User;
 
 public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
 
@@ -30,6 +28,9 @@ public interface ObjectiveJpaRepository extends JpaRepository<Objective, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Objective o SET o.idx = o.idx - 1 WHERE o.idx >= :lBound AND o.idx <= :uBound AND o.user.id = :userId AND o.id != :targetId")
     void bulkUpdateIdxDecrease(@Param("lBound") int lowerBound, @Param("uBound") int upperBound, @Param("userId") Long userId, @Param("targetId") Long targetId);
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Objective  o SET o.idx = o.idx - 1 WHERE o.idx >= :lBound AND o.user.id = :userId")
+    void bulkUpdateIdxDecreaseAfter(@Param("lBound") int lowerBound, @Param("userId") Long userId);
     List<Objective> findAllByUserIn(List<User> userList);
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #248 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Objective 삭제 시 Index 감소가 되지 않던 것 수정
- KeyResult, Task 생성, 삭제 시 Index 위치 조정 로직 변경

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
Objective, KeyResult, Task 생성 삭제 시 Index 수정하는 쿼리 최적화 수행하였습니다. 일례로 task만 보여드리도록 하겠습니다! 어차피 내부 DB SQL문은 똑같습니다 !!

[변경 전 쿼리 사진]
<img width="224" alt="스크린샷 2024-03-12 오후 6 44 55" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/65c88eab-8d3d-4986-a8a9-1fb70760ea47">


[변경 후 쿼리 사진]
<img width="213" alt="스크린샷 2024-03-12 오후 6 47 33" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/17a01db1-8dd5-47ce-b999-0e48584f4682">

