### PR TITLE
[Fix] #261 - O-KR 히스토리 조회 API 변경사항 반영

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/objective/dto/response/HistoryResponseDto.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/dto/response/HistoryResponseDto.java
@@ -1,20 +1,12 @@
 package org.moonshot.objective.dto.response;
 
 import java.util.List;
-import java.util.Map;
-import org.moonshot.objective.model.Criteria;
 
 public record HistoryResponseDto(
         List<ObjectiveGroupByYearDto> groups,
-        List<YearDto> years,
         List<String> categories
 ) {
-    public static HistoryResponseDto of(List<ObjectiveGroupByYearDto> groups, Map<Integer, Integer> years,
-                                        List<String> categories, Criteria criteria) {
-        return new HistoryResponseDto(
-                groups,
-                YearDto.of(years),
-                categories.stream().distinct().toList()
-        );
+    public static HistoryResponseDto of(List<ObjectiveGroupByYearDto> groups, List<String> categories) {
+        return new HistoryResponseDto(groups, categories.stream().distinct().toList());
     }
 }

--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.common.model.Period;
@@ -120,11 +119,6 @@ public class ObjectiveService implements IndexService {
         List<Objective> objectives = objectiveRepository.findObjectives(userId, year, category, criteria);
         Map<Integer, List<Objective>> groups = objectives.stream()
                 .collect(Collectors.groupingBy(objective -> objective.getPeriod().getStartAt().getYear()));
-        Map<Integer, Integer> years = groups.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Entry::getKey,
-                        entry -> entry.getValue().size()
-                ));
         List<String> categories = objectives.stream().map(objective -> objective.getCategory().getValue()).toList();
 
         List<ObjectiveGroupByYearDto> groupList = groups.entrySet().stream()
@@ -142,7 +136,7 @@ public class ObjectiveService implements IndexService {
                     .sorted(Comparator.comparingInt(ObjectiveGroupByYearDto::year).reversed()).toList();
         }
 
-        return HistoryResponseDto.of(groupsSortedByCriteria, years, categories, criteria);
+        return HistoryResponseDto.of(groupsSortedByCriteria, categories);
     }
 
     @Override


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #261 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
O-KR 히스토리 조회 API 변경사항 반영
- 데이터 스펙이 변경됨에 따라 year를 stream에 처리하는 로직이 제거되어 어느정도 성능이 빨라졌는지 궁금해서 JMeter 테스트 결과를 아래에첨부하였습니다~ 동시에 쓰레드 100개가 100번 요청하는 상황으로 부하테스트를 진행하였습니다.

아래 테스트 결과를 보시면 기존 방식과 변경된 방식에서 평균 API latency는 비슷하지만 95% 99% 즉 가장 최악의 API 수행 시간은 기존 방식이 오래 걸림을 확인할 수 있었습니다. 아마 stream 처리 때문에 처리될 쓰레드가 쌓이면서 처리시간이 늘어나지 않았을까 추측해봅니다.
그리고 대규모 건당 처리량이 엄청 드라마틱하게 늘어난 것은 아니지만 꽤나 늘어난 것을 볼 수 있습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->

[기존 API 구현 방법의 테스트]
<img width="1021" alt="스크린샷 2024-04-08 오후 9 49 08" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/b3f853e3-b4ea-4ef8-b793-2acbc46a0bd1">
<img width="1010" alt="스크린샷 2024-04-08 오후 9 49 23" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/c6047f31-8a80-4447-b193-7341e09b046c">



[변경된 API 구현 방법의 테스트]
<img width="1021" alt="스크린샷 2024-04-08 오후 9 51 48" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/cec72167-2bb6-46fb-8a36-23768de7c49c">
<img width="1017" alt="스크린샷 2024-04-08 오후 9 51 58" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/04f4a593-92d6-4297-842c-cc3961995926">
<img width="1010" alt="스크린샷 2024-04-08 오후 9 52 05" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/f83c3944-b45f-4221-b1c4-1a15f2d3b7ed">

