### PR TITLE
[Refactor] #263 - User 데이터 캐싱

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -46,7 +46,7 @@ public class ObjectiveService implements IndexService {
     private final ObjectiveRepository objectiveRepository;
 
     public void createObjective(final Long userId, final OKRCreateRequestDto request) {
-        User user =  userRepository.findById(userId)
+        User user =  userRepository.findByIdWithCache(userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
 
         List<Objective> objectives = objectiveRepository.findAllByUserId(userId);

--- a/moonshot-auth/src/main/java/org/moonshot/config/CacheConfig.java
+++ b/moonshot-auth/src/main/java/org/moonshot/config/CacheConfig.java
@@ -1,0 +1,35 @@
+package org.moonshot.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public CacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofSeconds(60 * 60));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    }
+
+}

--- a/moonshot-auth/src/main/java/org/moonshot/config/RedisConfig.java
+++ b/moonshot-auth/src/main/java/org/moonshot/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package org.moonshot.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,10 +10,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
+@RequiredArgsConstructor
 public class RedisConfig {
 
     @Value("${redis.host}")
@@ -19,6 +23,8 @@ public class RedisConfig {
 
     @Value("${redis.port}")
     private int port;
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -30,7 +36,7 @@ public class RedisConfig {
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
     }

--- a/moonshot-auth/src/main/java/org/moonshot/security/service/UserPrincipalDetailsService.java
+++ b/moonshot-auth/src/main/java/org/moonshot/security/service/UserPrincipalDetailsService.java
@@ -17,7 +17,7 @@ public class UserPrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findById(Long.parseLong(username))
+        return userRepository.findByIdWithCache(Long.parseLong(username))
                 .map(UserPrincipal::new)
                 .orElseThrow(UnauthorizedException::new);
     }

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepository.java
@@ -1,0 +1,10 @@
+package org.moonshot.user.repository;
+
+import java.util.Optional;
+import org.moonshot.user.model.User;
+
+public interface UserCustomRepository {
+
+    Optional<User> findByIdWithCache(Long id);
+
+}

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
@@ -20,4 +20,5 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
         return Optional.ofNullable(queryFactory.selectFrom(user)
                 .where(user.id.eq(id)).fetchOne());
     }
+
 }

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.moonshot.user.model.User;
 import org.springframework.cache.annotation.Cacheable;
 
-@Slf4j
 @RequiredArgsConstructor
 public class UserCustomRepositoryImpl implements UserCustomRepository {
 
@@ -18,7 +17,6 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
     @Override
     @Cacheable(value = "user", cacheManager = "redisCacheManager")
     public Optional<User> findByIdWithCache(final Long id) {
-        log.info("id : " + id);
         return Optional.ofNullable(queryFactory.selectFrom(user)
                 .where(user.id.eq(id)).fetchOne());
     }

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import static org.moonshot.user.model.QUser.user;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.moonshot.user.model.User;
 import org.springframework.cache.annotation.Cacheable;
 

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.moonshot.user.repository;
+
+import static org.moonshot.user.model.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.moonshot.user.model.User;
+import org.springframework.cache.annotation.Cacheable;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    @Cacheable(value = "user", cacheManager = "redisCacheManager")
+    public Optional<User> findByIdWithCache(final Long id) {
+        log.info("id : " + id);
+        return Optional.ofNullable(queryFactory.selectFrom(user)
+                .where(user.id.eq(id)).fetchOne());
+    }
+}

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserJpaRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserJpaRepository.java
@@ -1,0 +1,19 @@
+package org.moonshot.user.repository;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.moonshot.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findUserBySocialId(String socialId);
+    Optional<User> findUserByNickname(String nickname);
+    @Query("SELECT u FROM User u WHERE u.deleteAt < :currentDate")
+    List<User> findIdByDeletedAtBefore(LocalDateTime currentDate);
+
+}
+

--- a/moonshot-domain/src/main/java/org/moonshot/user/repository/UserRepository.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/repository/UserRepository.java
@@ -1,19 +1,4 @@
 package org.moonshot.user.repository;
 
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import org.moonshot.user.model.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-public interface UserRepository extends JpaRepository<User, Long> {
-
-    Optional<User> findUserBySocialId(String socialId);
-    Optional<User> findUserByNickname(String nickname);
-    @Query("SELECT u FROM User u WHERE u.deleteAt < :currentDate")
-    List<User> findIdByDeletedAtBefore(LocalDateTime currentDate);
-
+public interface UserRepository extends UserJpaRepository, UserCustomRepository {
 }
-


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #263 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
```
Hibernate: 
    select
        u1_0.user_id,
        ****
    from
        `user` u1_0 
    where
        u1_0.user_id=?
Hibernate: 
    select
        distinct o1_0.objective_id,
        ****
    from
        objective o1_0 
    join
        `user` u1_0 
            on u1_0.user_id=o1_0.user_id 
    where
        u1_0.user_id=? 
        and o1_0.is_closed=0 
    order by
        o1_0.idx
Hibernate: 
    select
        u1_0.user_id,
        ****
    from
        `user` u1_0 
    where
        u1_0.user_id=?
```

**별 표시는 쿼리문을 간략히 줄이기 위해 다 지우고 쓴 것임을 먼저 알려드리겠습니다 ! 참고해서 봐주세요~**

히스토리 조회 쿼리인데 user 정보를 항상 조회하는데에 오버헤드가 매우 크다고 생각했습니다. 또한 @LoginUser 어노테이션에 userId를 주입해줄 때 DB에서 유저의 정보를 조회해서 user의 id를 주입해주는데 항상 매 api 요청마다 DB에 다녀오는 것은 성능상 좋지 않다고 판단하였습니다. 또한 특정 API에서는 user 조회를 2번하는 경우도 존재하여 캐시를 적용하기로 결정하였습니다.

### 근데 왜 Redis 였나?
저희는 유저의 refresh token의 저장소를 redis에 저장하여 사용하고 있습니다. 또한 redis에 대한 **부하**가 그렇게 크지 않다고 판단했고 추가적인 저장소나 캐싱을 위한 **인프라 작업**이 필요없을 것 같아 Redis를 적용하기로 했습니다. 또한 Redis를 적용했을 때의 **성능**도 괜찮다고 판단하여 적용하려 했습니다.

### 성능 비교
**[User 데이터를 캐싱하지 않고 DB에 가져오면서 API를 처리할 때]**
<img width="1300" alt="스크린샷 2024-04-10 오후 5 33 06" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/da8a14ef-a9d2-4e33-b7e3-09026c5ace35">

**[Redis에 캐시하여 API를 처리할 때]**
<img width="1295" alt="스크린샷 2024-04-10 오후 5 36 55" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/8e11e229-906d-4b42-9766-ca74a4af7c68">

일단 10개의 쓰레드가 100번의 요청의 부하를 가했을 때 테스트 내용입니다. **평균 8배 이상 빠르다**는 것을 볼 수 있고 99% 최악의 처리 시간을 고려하더라도 **2배 가량 빠르다**는 것을 볼 수 있었습니다.


### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
고민 사항은 User의 도메인 데이터를 그대로 Redis에 캐싱하는 것에 대해서 보안적으로 괜찮을까? 라는 제 스스로의 질문이 있었습니다. 이 부분에 대해선 일단 redis 자체에 접근할 수 있는 방법이 ec2 내부에서밖에 접근하지 못하기 때문에 보안적으로 문제 없을거라고 생각합니다만.. 보완점이 생기거나 추가 아이디어가 생긴다면 적용토록 하겠습니다!

또한 캐시 데이터의 TTL은 3600초(1시간)을 적용하였는데 access token의 유효 시간인 20분으로 적용해야 할 지, 더 늘려야 할지에 대한 고민을 했었는데 이 부분은 운영하면서 노하우를 쌓아서 추가 튜닝을 해보도록 하겠습니다~
