### PR TITLE
[Refactor] #267 - 유저 회원가입 이벤트 발행 비동기 처리

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/config/AsyncConfig.java
+++ b/moonshot-api/src/main/java/org/moonshot/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package org.moonshot.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(4);
+        executor.setKeepAliveSeconds(60);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setThreadNamePrefix("async-executor-");
+        executor.initialize();
+        return executor;
+    }
+
+}

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserSignUpService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserSignUpService.java
@@ -1,0 +1,31 @@
+package org.moonshot.user.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.moonshot.discord.SignUpEvent;
+import org.moonshot.user.model.User;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSignUpService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishSignUpEvent(User user) {
+        eventPublisher.publishEvent(SignUpEvent.of(
+                user.getName(),
+                user.getEmail() == null ? "" : user.getEmail(),
+                user.getSocialPlatform().toString(),
+                LocalDateTime.now(),
+                user.getImageUrl()
+        ));
+    }
+
+}

--- a/moonshot-api/src/main/java/org/moonshot/user/service/social/GoogleLoginStrategy.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/social/GoogleLoginStrategy.java
@@ -2,10 +2,8 @@ package org.moonshot.user.service.social;
 
 import static org.moonshot.user.service.validator.UserValidator.isNewUser;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.moonshot.discord.SignUpEvent;
 import org.moonshot.jwt.JwtTokenProvider;
 import org.moonshot.jwt.TokenResponse;
 import org.moonshot.openfeign.dto.response.google.GoogleInfoResponse;
@@ -16,10 +14,9 @@ import org.moonshot.user.dto.request.SocialLoginRequest;
 import org.moonshot.user.dto.response.SocialLoginResponse;
 import org.moonshot.user.model.User;
 import org.moonshot.user.repository.UserRepository;
+import org.moonshot.user.service.UserSignUpService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -28,19 +25,17 @@ public class GoogleLoginStrategy implements SocialLoginStrategy {
 
     @Value("${google.client-id}")
     private String googleClientId;
-
     @Value("${google.client-secret}")
     private String googleClientSecret;
-
     @Value("${google.redirect-url}")
     private String googleRedirectUrl;
 
     private final GoogleAuthApiClient googleAuthApiClient;
     private final GoogleApiClient googleApiClient;
 
-    private final ApplicationEventPublisher eventPublisher;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final UserSignUpService userSignUpService;
 
     @Override
     @Transactional
@@ -64,7 +59,7 @@ public class GoogleLoginStrategy implements SocialLoginStrategy {
                     .email(userResponse.email())
                     .build());
             user = newUser;
-            publishSignUpEvent(newUser);
+            userSignUpService.publishSignUpEvent(newUser);
         } else {
             user = findUser.get();
             user.resetDeleteAt();
@@ -76,18 +71,6 @@ public class GoogleLoginStrategy implements SocialLoginStrategy {
     @Override
     public boolean support(String provider) {
         return provider.equals("GOOGLE");
-    }
-
-    @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void publishSignUpEvent(User user) {
-        eventPublisher.publishEvent(SignUpEvent.of(
-                user.getName(),
-                user.getEmail() == null ? "" : user.getEmail(),
-                user.getSocialPlatform().toString(),
-                LocalDateTime.now(),
-                user.getImageUrl()
-        ));
     }
 
 }

--- a/moonshot-api/src/main/java/org/moonshot/user/service/social/SocialLoginStrategy.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/social/SocialLoginStrategy.java
@@ -2,12 +2,10 @@ package org.moonshot.user.service.social;
 
 import org.moonshot.user.dto.request.SocialLoginRequest;
 import org.moonshot.user.dto.response.SocialLoginResponse;
-import org.moonshot.user.model.User;
 
 public interface SocialLoginStrategy {
 
     SocialLoginResponse login(final SocialLoginRequest request);
     boolean support(String provider);
-    void publishSignUpEvent(final User user);
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #267 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
유저 회원가입 이벤트 발행 로직을 비동기로 처리하도록 변경하였습니다.

비동기는 기본적으로 해당 요청의 반환 결과를 기다리지 않고 다음 실행을 이어나가는 방법을 말합니다. 로그인 특성상 회원가입 이벤트를 Discord에 로깅하는데 로깅하는 데까지 유저가 기다리는 시간이 많을 뿐더러, 이는 유저에게 불필요한 대기시간이므로 비동기로 분리하였습니다.

비동기로 분리했을 떄의 API 수행 시간 차이는 다음과 같이 테스트하였습니다.
- local 환경에서는 Discord 웹훅 연동이 되어 있지 않기 때문에 로깅을 하는데에 0.5초가 걸린다고 상정하고 Thread.sleep(500);을 통해 event 발행 메소드가 0.5초동안 수행되도록 하였습니다.

[기존 로직을 통해 이벤트를 발행한 경우]
<img width="240" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/28c9df73-61d0-4c6c-b496-7cf5b0ec7e9c">

[비동기로 변경된 로직으로 이벤트를 발행한 경우]
<img width="228" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/15343d88-bb48-4611-b708-ef4ecd796078">

위 테스트 결과를 보시면 거의 이벤트의 I/O 시간만큼 유저의 회원가입 시간이 오래 걸린다는 것을 확인할 수 있습니다. 이를 통해 비동기 처리의 효과를 확인할 수 있습니다.

그리고 비동기 처리를 위한 쓰레드 풀을 설정하였는데요.
저희는 EC2 프리티어를 사용하고 있어서 싱글 코어입니다.
싱글 코어인데 쓰레드 풀의 크기를 크게 설정하면 정상적인 처리가 되지 않을 뿐더러, 회원가입 이벤트가 동시다발적으로 많이 발생하지 않을 것입니다. 그래서 쓰레드 풀의 크기를 4로 설정하고 keep-alive 시간도 60초로 설정하여 정상적으로 처리되도록 하였습니다.
또한, 대기 큐 오버플로우가 발생하면 이벤트를 받지 않고 폐기하도록 정책을 설정하였습니다.

잘못된 점 있으면 지적해주시기 바랍니다 감사합니다.

**첨언** : 궁금해하실거 같아서 덧붙히자면, @Async 어노테이션은 AOP로 동작하기 떄문에 self-invocation(자가 호출) 즉, 같은 클래스 내에서 호출을 못합니다. 따라서 SignUpService로 클래스를 분리하고 빈을 주입받아 호출하도록 하였습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
