### PR TITLE
[Feat] #272 - TaskService 테스트 코드 작성

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/task/service/validator/TaskValidator.java
+++ b/moonshot-api/src/main/java/org/moonshot/task/service/validator/TaskValidator.java
@@ -22,7 +22,7 @@ public class TaskValidator {
     }
 
     public static void validateIndexUnderMaximum(final int requestIndex, final int totalTaskListSize) {
-        if (requestIndex > totalTaskListSize) {
+        if (requestIndex > totalTaskListSize || requestIndex < 0) {
             throw new BadRequestException(INVALID_TASK_INDEX);
         }
     }

--- a/moonshot-api/src/test/java/org/moonshot/task/service/TaskServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/task/service/TaskServiceTest.java
@@ -1,0 +1,69 @@
+package org.moonshot.task.service;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.moonshot.exception.BadRequestException;
+import org.moonshot.keyresult.model.KeyResult;
+import org.moonshot.keyresult.repository.KeyResultRepository;
+import org.moonshot.objective.model.Objective;
+import org.moonshot.task.dto.request.TaskSingleCreateRequestDto;
+import org.moonshot.task.repository.TaskRepository;
+import org.moonshot.user.model.User;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceTest {
+
+    @Mock
+    private KeyResultRepository keyResultRepository;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    private static User fakeUser;
+
+    @BeforeAll
+    static void setUp() {
+        Long fakeUserId = 1L;
+        String fakeUserNickname = "tester";
+        fakeUser = User.buildWithId().id(fakeUserId).nickname(fakeUserNickname).build();
+    }
+
+    @Test
+    @DisplayName("단일 Task를 생성합니다")
+    void 단일_Task를_생성합니다() {
+        // given
+        Objective testObjective = mock(Objective.class);
+        KeyResult testKeyResult = mock(KeyResult.class);
+        TaskSingleCreateRequestDto request = new TaskSingleCreateRequestDto(
+                1L, "test task", 0);
+
+        given(keyResultRepository.findKeyResultAndObjective(request.keyResultId())).willReturn(Optional.of(testKeyResult));
+        given(testKeyResult.getObjective()).willReturn(testObjective);
+        given(testObjective.getUser()).willReturn(fakeUser);
+        given(testKeyResult.getId()).willReturn(1L);
+
+        // when
+        taskService.createTask(request, fakeUser.getId());
+
+        // then
+        verify(taskRepository, times(1)).bulkUpdateTaskIdxIncrease(any(Integer.class), any(Integer.class), eq(1L), eq(-1L));
+    }
+
+}


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #272 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
BDDMocktio를 사용하여  Task생성과 관련된 테스트 코드를 작성하였습니다. 

우리 서비스의 경우 objective → keyResult → task 와 같이 의존성을 가지고 있으므로 테스트를 하기 위해서는 많은 세팅이 필요하기 때문에 mock 객체를 통해 테스트 하려는 코드가 의존하고 있는 객체를 가짜로 만들어 의존성 제거하고 객체의 동작을 통제할 수 있었습니다.
given절에는 기존 service 코드의 행위들을 mock객체에도 지정해주어야 하는데 몇몇 부분을 누락하여 진행하여 작성하는데 시간이 걸렸습니다. 

또한 생성을 검증할 때, 현재 mock객체를 사용하고 있기 때문에 직접적으로 task가 생성되었는지 검증할 방법이 없으므로, 다른 방법을 통해서 확인해야합니다.따라서 task관련해서는 bulkUpdateIdx를 이용해서 검증을 진행하였습니다.

테스트코드를 작성하면서 taskIdx에 -1을 넣으면 test에 성공하지 못하는 점을 발견하여 taskValidator를 수정하였습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
추가적으로 필요한 테스트코드가 있다면 알려주시면 작업하겠습니다 !
