### PR TITLE
[Feat] #274 - LogService 테스트 코드 작성

### DIFF
--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -165,4 +165,18 @@ public class LogServiceTest {
         assertThat(logService.calculateKRProgressBar(testLog, testKeyResult.getTarget())).isEqualTo((short)10);
     }
 
+    @Test
+    @DisplayName("KeyResult에 대한 Log를 조회합니다.")
+    void KeyResult에_대한_Log를_조회합니다() {
+        //given
+        KeyResult testKeyResult = mock(KeyResult.class);
+        List<Log> testLogList = mock(List.class);
+
+        given(testLogList.size()).willReturn(2);
+        given(logRepository.findAllByKeyResultOrderByIdDesc(testKeyResult)).willReturn(testLogList);
+
+        //when,then
+        assertThat(logService.getLogList(testKeyResult).size()).isEqualTo(2);
+    }
+
 }

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -103,4 +103,18 @@ public class LogServiceTest {
                 .hasMessage("Log 입력값은 이전 값과 동일할 수 없습니다.");
     }
 
+    @Test
+    @DisplayName("KeyResult가 수정되면 체크인 로그를 추가합니다.")
+    void KeyResult가_수정되면_체크인_로그를_추가합니다() {
+        //given
+        KeyResult testKeyResult = mock(KeyResult.class);
+        KeyResultModifyRequestDto request = new KeyResultModifyRequestDto(
+                1L, null, null, null, 100000L, null, "new check-in");
+        //when
+        logService.createUpdateLog(request, testKeyResult);
+
+        //then
+        verify(logRepository, times(1)).save(any(Log.class));
+    }
+    
 }

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -52,9 +54,10 @@ public class LogServiceTest {
         fakeUser = User.buildWithId().id(fakeUserId).nickname(fakeUserNickname).build();
     }
 
-    @Test
+    @ParameterizedTest
     @DisplayName("KeyResult의 진척 상황을 기록하고 체크인 로그를 추가합니다.")
-    void KeyResult의_진척상황을_기록하고_체크인_로그를_추가합니다() {
+    @CsvSource(value = {"1, true", "100, false"})
+    void KeyResult의_진척상황을_기록하고_체크인_로그를_추가합니다(short progress, boolean expected) {
         // given
         Objective testObjective = mock(Objective.class);
         KeyResult testKeyResult = mock(KeyResult.class);
@@ -70,7 +73,7 @@ public class LogServiceTest {
         given(logRepository.save(any(Log.class))).willReturn(testLog);
         given(testObjective.getKeyResultList()).willReturn(List.of(testKeyResult));
 
-        given(testObjective.getProgress()).willReturn((short)1);
+        given(testObjective.getProgress()).willReturn((short)progress);
 
         //when
         Optional<AchieveResponseDto> response = logService.createRecordLog(fakeUser.getId(), request);
@@ -78,7 +81,7 @@ public class LogServiceTest {
         //then
         verify(testKeyResult, times(1)).modifyProgress(anyShort());
         verify(testObjective, times(1)).modifyProgress(anyShort());
-        assertThat(response.isEmpty()).isEqualTo(true);
+        assertThat(response.isEmpty()).isEqualTo(expected);
     }
 
     @Test

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -116,5 +116,38 @@ public class LogServiceTest {
         //then
         verify(logRepository, times(1)).save(any(Log.class));
     }
-    
+
+    @Test
+    @DisplayName("Objective와 함께 KeyResult가 생성되면 체크인 로그를 추가합니다.")
+    void Objective와_함께_KeyResult가_생성되면_체크인_로그를_추가합니다() {
+        //given
+        KeyResult testKeyResult = mock(KeyResult.class);
+        Long testKeyResultId = 1L;
+        KeyResultCreateRequestInfoDto request = new KeyResultCreateRequestInfoDto("test KR", LocalDate.now(), LocalDate.now(), 0, 2000L, "건", null);
+
+        given(keyResultRepository.findById(testKeyResultId)).willReturn(Optional.of(testKeyResult));
+
+        //when
+        logService.createKRLog(request, testKeyResultId);
+
+        //then
+        verify(logRepository, times(1)).save(any(Log.class));
+    }
+
+    @Test
+    @DisplayName("KeyResult가 추가적으로 생성되면 체크인 로그를 추가합니다.")
+    void KeyResult가_추가적으로_생성되면_체크인_로그를_추가합니다() {
+        //given
+        KeyResult testKeyResult = mock(KeyResult.class);
+        Long testKeyResultId = 1L;
+        KeyResultCreateRequestDto request = new KeyResultCreateRequestDto(1L, "test KR", LocalDate.now(), LocalDate.now(), 0, 2000L, "건");
+
+        given(keyResultRepository.findById(testKeyResultId)).willReturn(Optional.of(testKeyResult));
+
+        //when
+        logService.createKRLog(request, testKeyResultId);
+
+        //then
+        verify(logRepository, times(1)).save(any(Log.class));
+    }
 }

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -150,4 +150,19 @@ public class LogServiceTest {
         //then
         verify(logRepository, times(1)).save(any(Log.class));
     }
+
+    @Test
+    @DisplayName("진척 상황값이 입력되면 KR 달성률을 계산합니다.")
+    void 진척상황_값이_입력되면_KR_달성률을_계산합니다() {
+        //given
+        KeyResult testKeyResult = mock(KeyResult.class);
+        Log testLog = mock(Log.class);
+
+        given(testKeyResult.getTarget()).willReturn(1000L);
+        given(testLog.getCurrNum()).willReturn(100L);
+
+        //when, then
+        assertThat(logService.calculateKRProgressBar(testLog, testKeyResult.getTarget())).isEqualTo((short)10);
+    }
+
 }

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -81,4 +81,26 @@ public class LogServiceTest {
         assertThat(response.isEmpty()).isEqualTo(true);
     }
 
+    @Test
+    @DisplayName("KeyResult의 진척 상황의 값이 이전 진척 상황 값과 동일하여 예외가 발생합니다.")
+    void KeyResult의_진척상황_값이_이전_진척상황_값과_동일하여_예외가_발생합니다() {
+        //given
+        Objective testObjective = mock(Objective.class);
+        KeyResult testKeyResult = mock(KeyResult.class);
+        Log testPrevLog = mock(Log.class);
+        LogCreateRequestDto request = new LogCreateRequestDto(1L, 1000L, "new log content");
+
+        given(keyResultRepository.findKeyResultAndObjective(request.keyResultId())).willReturn(Optional.of(testKeyResult));
+        given(testKeyResult.getObjective()).willReturn(testObjective);
+        given(testObjective.getUser()).willReturn(fakeUser);
+
+        given(logRepository.findLatestLogByKeyResultId(eq(LogState.RECORD), anyLong())).willReturn(Optional.of(testPrevLog));
+        given(testPrevLog.getCurrNum()).willReturn(1000L);
+
+        //when, then
+        assertThatThrownBy(() -> logService.createRecordLog(fakeUser.getId(), request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Log 입력값은 이전 값과 동일할 수 없습니다.");
+    }
+
 }

--- a/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
+++ b/moonshot-api/src/test/java/org/moonshot/log/service/LogServiceTest.java
@@ -1,0 +1,84 @@
+package org.moonshot.log.service;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.moonshot.exception.BadRequestException;
+import org.moonshot.keyresult.dto.request.KeyResultCreateRequestDto;
+import org.moonshot.keyresult.dto.request.KeyResultCreateRequestInfoDto;
+import org.moonshot.keyresult.dto.request.KeyResultModifyRequestDto;
+import org.moonshot.keyresult.model.KeyResult;
+import org.moonshot.keyresult.repository.KeyResultRepository;
+import org.moonshot.log.dto.request.LogCreateRequestDto;
+import org.moonshot.log.dto.response.AchieveResponseDto;
+import org.moonshot.log.model.Log;
+import org.moonshot.log.model.LogState;
+import org.moonshot.log.repository.LogRepository;
+import org.moonshot.objective.model.Objective;
+import org.moonshot.user.model.User;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class LogServiceTest {
+
+    @Mock
+    private KeyResultRepository keyResultRepository;
+    @InjectMocks
+    private LogService logService;
+    @Mock
+    private LogRepository logRepository;
+
+    private static User fakeUser;
+
+
+    @BeforeAll
+    static void setUp() {
+        Long fakeUserId = 1L;
+        String fakeUserNickname = "tester";
+        fakeUser = User.buildWithId().id(fakeUserId).nickname(fakeUserNickname).build();
+    }
+
+    @Test
+    @DisplayName("KeyResult의 진척 상황을 기록하고 체크인 로그를 추가합니다.")
+    void KeyResult의_진척상황을_기록하고_체크인_로그를_추가합니다() {
+        // given
+        Objective testObjective = mock(Objective.class);
+        KeyResult testKeyResult = mock(KeyResult.class);
+        Log testLog = mock(Log.class);
+        Log testPrevLog = mock(Log.class);
+        LogCreateRequestDto request = new LogCreateRequestDto(1L, 1000L, "new log content");
+
+        given(keyResultRepository.findKeyResultAndObjective(request.keyResultId())).willReturn(Optional.of(testKeyResult));
+        given(testKeyResult.getObjective()).willReturn(testObjective);
+        given(testObjective.getUser()).willReturn(fakeUser);
+
+        given(logRepository.findLatestLogByKeyResultId(eq(LogState.RECORD), anyLong())).willReturn(Optional.of(testPrevLog));
+        given(logRepository.save(any(Log.class))).willReturn(testLog);
+        given(testObjective.getKeyResultList()).willReturn(List.of(testKeyResult));
+
+        given(testObjective.getProgress()).willReturn((short)1);
+
+        //when
+        Optional<AchieveResponseDto> response = logService.createRecordLog(fakeUser.getId(), request);
+
+        //then
+        verify(testKeyResult, times(1)).modifyProgress(anyShort());
+        verify(testObjective, times(1)).modifyProgress(anyShort());
+        assertThat(response.isEmpty()).isEqualTo(true);
+    }
+
+}


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #274 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- LogService 내의 메서드에 대한 테스트 코드를 작성하였습니다.
<img width="613" alt="스크린샷 2024-05-28 오후 5 08 33" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/ad3689c9-1834-499d-bafc-c77b734739d6">

<br>

- 진척 상황 입력 후 로그가 생성되는 경우 isKeyResult에 따른 반환값이 다른데, 하나의 메서드에서 처리할 수 있도록 `@ParameterizedTest`를 통해 구현하였습니다. 해당 테스트 결과는 다음과 같습니다.

<img width="423" alt="스크린샷 2024-05-28 오후 5 05 29" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/75068759/efe0d175-71a1-4ed8-a1fd-03c06dad5a3e">


### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- 이번에도 Stubbing을 하는 부분에서 시행착오가 있었습니다 .. 하하
- 추가적으로 필요한 테스트 코드가 있다면 알려주세요 !

### 🔗참고 
https://velog.io/@ohzzi/junit5-parameterizedtest




