### PR TITLE
[Fix] #286 - 소셜 쿼리 오류 수정 및 닉네임 정규표현식 수정

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
+++ b/moonshot-api/src/main/java/org/moonshot/objective/service/ObjectiveService.java
@@ -11,9 +11,7 @@ import static org.moonshot.validator.IndexValidator.isIndexIncreased;
 import static org.moonshot.validator.IndexValidator.isSameIndex;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.moonshot.common.model.Period;
@@ -144,7 +142,10 @@ public class ObjectiveService implements IndexService {
     @Transactional(readOnly = true)
     public List<SocialOKRResponseDto> getObjectiveSocial() {
         List<Objective> objectives = objectiveRepository.findSocialObjectives();
+        Set<Long> objectiveIds = new LinkedHashSet<>();
+
         return objectives.stream()
+                .filter(objective -> objectiveIds.add(objective.getId()))
                 .map(SocialOKRResponseDto::of)
                 .toList();
     }

--- a/moonshot-common/src/main/java/org/moonshot/constants/RegexConstants.java
+++ b/moonshot-common/src/main/java/org/moonshot/constants/RegexConstants.java
@@ -1,5 +1,5 @@
 package org.moonshot.constants;
 
 public class RegexConstants {
-    public static final String nicknameRegex = "^[a-zA-Z0-9가-힣]{1,7}$";
+    public static final String nicknameRegex = "^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]{1,7}$";
 }

--- a/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveCustomRepositoryImpl.java
+++ b/moonshot-domain/src/main/java/org/moonshot/objective/repository/ObjectiveCustomRepositoryImpl.java
@@ -3,11 +3,17 @@ package org.moonshot.objective.repository;
 import static org.moonshot.keyresult.model.QKeyResult.keyResult;
 import static org.moonshot.objective.model.QObjective.objective;
 import static org.moonshot.task.model.QTask.task;
+import static org.moonshot.user.model.QUser.user;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -72,12 +78,12 @@ public class ObjectiveCustomRepositoryImpl implements ObjectiveCustomRepository 
 
     @Override
     public List<Objective> findSocialObjectives() {
-        return queryFactory.selectFrom(objective).distinct()
-                .join(objective.user).fetchJoin()
+        return queryFactory.selectFrom(objective)
+                .join(objective.user, user).fetchJoin()
                 .leftJoin(objective.keyResultList, keyResult).fetchJoin()
                 .leftJoin(keyResult.taskList, task)
                 .where(objective.isPublic.eq(true))
-                .orderBy(objective.heartCount.desc(), objective.id.desc(), keyResult.idx.asc(), task.id.asc())
+                .orderBy(objective.heartCount.desc(), objective.id.desc(), keyResult.idx.asc(), task.idx.asc())
                 .limit(10)
                 .fetch();
     }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #286 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
1. 운영서버에서 유저가 초성으로만 닉네임을 입력하여 서버에러가 발생하였습니다.
수정 전 정규식은 일반 한글만 가능하도록 되어있었는데 자음 초성, 모음 초성도 가능하도록 정규식을 수정하였습니다. 해당 부분 클라 측에도 전달 예정입니다!

2. 소셜 API에서 다음과 같은 쿼리 에러가 발생하여서 해당 부분 수정하였습니다.
`Expression #3 of ORDER BY clause is not in SELECT list, references column 'moonshot.krl1_0.idx' which is not in SELECT list; this is incompatible with DISTINCT`

해당 에러는 DISTINCT를 사용할 때, ORDER BY절에 나열된 모든 컬럼들이 SELECT 리스트에 포함되어야 하는데 없어서 생긴 문제였습니다. 쿼리문에서 distinct를 제거하고 추후에 distinct를 해주는 방식으로 수정하였습니다. 순서를 보장해주기 위해서 LinkedHashSet을 사용하였습니다 !

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
