### PR TITLE
[Fix] 소셜 로그인 img_url 필드 MySQL 길이 대응

### DIFF
--- a/moonshot-api/src/main/resources/application.yml
+++ b/moonshot-api/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
 
   flyway:
     baseline-on-migrate: false
-    baseline-version: 2
+    baseline-version: 3
     enabled: false
 
 google:

--- a/moonshot-api/src/main/resources/db/migration/V4__DDL.sql
+++ b/moonshot-api/src/main/resources/db/migration/V4__DDL.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user MODIFY image_url VARCHAR(512);

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/User.java
@@ -38,7 +38,7 @@ public class User {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 512)
     private String imageUrl;
 
     private String email;


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #291 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
구글 로그인 시 image_url 길이가 255보다 길어 에러가 발생하는 상황을 발견하였습니다.

그래서 길이를 512로 변경하는 작업을 수행하였습니다.

Flyway 수정을 위해 dev, prod 서버 application.yml 수정 작업 완료하도록 하겠습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
