### PR TITLE
[Refactor] #294 - Redis 유저 조회 로직 개선

### DIFF
--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
@@ -1,14 +1,11 @@
 package org.moonshot.user.service;
 
-import static org.moonshot.response.ErrorType.NOT_FOUND_USER;
-import static org.moonshot.response.ErrorType.NOT_SUPPORTED_LOGIN_PLATFORM;
-import static org.moonshot.user.service.validator.UserValidator.hasChange;
-import static org.moonshot.user.service.validator.UserValidator.validateUserAuthorization;
+import static org.moonshot.response.ErrorType.*;
+import static org.moonshot.user.service.validator.UserValidator.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.moonshot.exception.BadRequestException;
 import org.moonshot.exception.NotFoundException;
 import org.moonshot.jwt.JwtTokenProvider;
@@ -23,6 +20,9 @@ import org.moonshot.user.repository.UserRepository;
 import org.moonshot.user.service.social.SocialLoginContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -50,25 +50,19 @@ public class UserService {
     }
 
     public void logout(final Long userId) {
-        User user =  userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
-        validateUserAuthorization(user.getId(), userId);
-
         jwtTokenProvider.deleteRefreshToken(userId);
     }
 
     public void withdrawal(final Long userId) {
-        User user =  userRepository.findById(userId)
+        User user = userRepository.findByIdWithCache(userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
-        validateUserAuthorization(user.getId(), userId);
 
         user.setDeleteAt();
     }
 
     public void modifyProfile(final Long userId, final UserInfoRequest request) {
-        User user =  userRepository.findById(userId)
+        User user = userRepository.findByIdWithCache(userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
-        validateUserAuthorization(user.getId(), userId);
 
         if (hasChange(request.nickname())) {
             user.modifyNickname(request.nickname());
@@ -79,13 +73,13 @@ public class UserService {
     }
 
     public UserInfoResponse getMyProfile(final Long userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdWithCache(userId)
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
         return UserInfoResponse.of(user);
     }
 
     public void updateUserProfileImage(final Long userId, final String imageUrl) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
+        User user = userRepository.findByIdWithCache(userId).orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
         user.modifyProfileImage(imageUrl);
     }
 

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
@@ -58,7 +58,7 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
 
         user.setDeleteAt();
-        logout(userId);
+        jwtTokenProvider.deleteRefreshToken(userId);
     }
 
     public void modifyProfile(final Long userId, final UserInfoRequest request) {

--- a/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
+++ b/moonshot-api/src/main/java/org/moonshot/user/service/UserService.java
@@ -58,6 +58,7 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));
 
         user.setDeleteAt();
+        logout(userId);
     }
 
     public void modifyProfile(final Long userId, final UserInfoRequest request) {

--- a/moonshot-auth/src/main/java/org/moonshot/jwt/JwtTokenProvider.java
+++ b/moonshot-auth/src/main/java/org/moonshot/jwt/JwtTokenProvider.java
@@ -1,29 +1,14 @@
 package org.moonshot.jwt;
 
-import static org.moonshot.response.ErrorType.DISCORD_LOG_APPENDER;
-import static org.moonshot.response.ErrorType.EXPIRED_TOKEN;
-import static org.moonshot.response.ErrorType.INVALID_REFRESH_TOKEN;
-import static org.moonshot.response.ErrorType.UNKNOWN_TOKEN;
-import static org.moonshot.response.ErrorType.UNSUPPORTED_TOKEN;
-import static org.moonshot.response.ErrorType.WRONG_SIGNATURE_TOKEN;
-import static org.moonshot.response.ErrorType.WRONG_TYPE_TOKEN;
+import static org.moonshot.response.ErrorType.*;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
-import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
 import javax.crypto.SecretKey;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.moonshot.constants.JWTConstants;
 import org.moonshot.exception.InternalServerException;
 import org.moonshot.exception.UnauthorizedException;
@@ -35,6 +20,18 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 
 @Slf4j
@@ -145,6 +142,7 @@ public class JwtTokenProvider {
             throw new InternalServerException(DISCORD_LOG_APPENDER);
         }
     }
+
     private Claims getBody(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())

--- a/moonshot-auth/src/main/java/org/moonshot/jwt/JwtTokenProvider.java
+++ b/moonshot-auth/src/main/java/org/moonshot/jwt/JwtTokenProvider.java
@@ -10,14 +10,12 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 
 import org.moonshot.constants.JWTConstants;
-import org.moonshot.exception.InternalServerException;
 import org.moonshot.exception.UnauthorizedException;
 import org.moonshot.security.UserAuthentication;
 import org.moonshot.security.service.UserPrincipalDetailsService;
 import org.moonshot.user.model.UserPrincipal;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -134,13 +132,7 @@ public class JwtTokenProvider {
     }
 
     public void deleteRefreshToken(Long userId) {
-        if (redisTemplate.hasKey(String.valueOf(userId))) {
-            ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-            String refreshToken = valueOperations.get(String.valueOf(userId));
-            redisTemplate.delete(refreshToken);
-        } else {
-            throw new InternalServerException(DISCORD_LOG_APPENDER);
-        }
+        redisTemplate.delete(String.valueOf(userId));
     }
 
     private Claims getBody(final String token) {

--- a/moonshot-auth/src/main/java/org/moonshot/security/service/UserPrincipalDetailsService.java
+++ b/moonshot-auth/src/main/java/org/moonshot/security/service/UserPrincipalDetailsService.java
@@ -1,13 +1,13 @@
 package org.moonshot.security.service;
 
-import lombok.RequiredArgsConstructor;
-import org.moonshot.exception.UnauthorizedException;
 import org.moonshot.user.model.UserPrincipal;
 import org.moonshot.user.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +17,7 @@ public class UserPrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByIdWithCache(Long.parseLong(username))
-                .map(UserPrincipal::new)
-                .orElseThrow(UnauthorizedException::new);
+        return new UserPrincipal(Long.parseLong(username));
     }
 
 }

--- a/moonshot-domain/src/main/java/org/moonshot/user/model/UserPrincipal.java
+++ b/moonshot-domain/src/main/java/org/moonshot/user/model/UserPrincipal.java
@@ -8,12 +8,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 public class UserPrincipal implements UserDetails {
 
-    private final User user;
+    private final Long userId;
     private final List<GrantedAuthority> grantedAuthorities;
 
-    public UserPrincipal(User user) {
-        this.user = user;
-        this.grantedAuthorities = user.getId() == null ?
+    public UserPrincipal(Long userId) {
+        this.userId = userId;
+        this.grantedAuthorities = this.userId == null ?
                                 List.of(new SimpleGrantedAuthority("ANONYMOUS")) :
                                 List.of(new SimpleGrantedAuthority("USER"));
     }
@@ -30,7 +30,7 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getName();
+        return String.valueOf(userId);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class UserPrincipal implements UserDetails {
     }
 
     public Long getUserId() {
-        return user.getId();
+        return this.userId;
     }
 
 }


### PR DESCRIPTION
## 🚀*PullRequest*🚀

### 📟 관련 이슈
- Resolved: #294 

### 💻 작업 내용
<!-- 작업 내용을 자유롭게 적어주세요. -->
- Security 로그인 로직 중에서 UserDetails에 유저를 Redis에서 조회하여 주입하고 이를 커스텀 어노테이션에서 사용하는 로직이 존재하였습니다. 하지만 Access Token의 userId만을 주입하여 사용하여도 충분히 문제없는 로직이었습니다. 따라서 Redis에서 유저를 조회하여 UserDetails에 삽입하는 로직을 제거하고 JMeter로 성능 테스트를 진행하였습니다.
- JwtTokenProvider와 UserService에서 제대로 동작하지 않거나 불필요한 검증 로직 및 조회 로직을 삭제하였습니다.
- UserService에서 사용되는 `userService.findById` 를 `userService.findByIdWithCache`를 이용하여 Redis에 캐싱되어 있는 유저 정보를 사용하여 처리하도록 하였습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->

`[JMeter 성능 테스트 - 기존 Redis 로직이었을 때 in Local]`
<img width="1301" alt="스크린샷 2024-07-02 오후 2 51 46" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/654cd939-9d4a-4417-8b58-7649312c7c69">


`[JMeter 성능 테스트 - Redis 조회 로직을 제거했을 때 in Local]`
<img width="1303" alt="스크린샷 2024-07-02 오후 2 54 08" src="https://github.com/MOONSHOT-Team/MOONSHOT-SERVER/assets/48898994/f32f0f8b-ae26-483b-aa95-3fbbfdb80be8">

로컬에서 테스트를 진행하였을 때 조회 API 10만 건에서 평균 13ms에서 11ms로 개선되었음을 확인하였습니다. 저희 서버 인프라 상 싱글 코어인만큼 성능 차이는 더 확연히 벌어질 것이라고 생각합니다.

모르는 부분이 있거나 이상한 점은 코드리뷰에 달아주세요 감사합니다 :)